### PR TITLE
Better typing for TagChildArg

### DIFF
--- a/htmltools/core.py
+++ b/htmltools/core.py
@@ -77,7 +77,6 @@ TagChild = Union["Tagifiable", "Tag", MetadataNode, str]
 TagChildArg = Union[
     TagChild,
     "TagList",
-    int,
     float,
     None,
     List["TagChildArg"],


### PR DESCRIPTION
For `TagChildArg`, the `Iterable["TagChildArg"]` is too permissive, because it allows sets and dicts. For example, the type checker doesn't flag these, but these result in run-time errors:

```R
div({"a", "b"})
#> TypeError: Invalid tag child type: <class 'set'>. Consider calling str() on this value be fore treating it as a tag child.

div({"a": "a"})
#> TypeError: Invalid tag child type: <class 'dict'>. Consider calling str() on this value b efore treating it as a tag child.
```