### PR TITLE
JSXTag() now queries for script tags that need render before inserting contents

### DIFF
--- a/htmltools/_jsx.py
+++ b/htmltools/_jsx.py
@@ -157,10 +157,10 @@ class JSXTag:
                 "  ReactDOM.render(",
                 component,
                 "  , container);",
-                "  var thisScript = document.querySelector('script[jsx-needs-render]');",
+                "  var thisScript = document.querySelector('script[data-needs-render]');",
                 f"  if (!thisScript) throw new Error('Failed to render JSXTag(\"{self.name}\")');",
                 "  thisScript.after(container);",
-                "  thisScript.removeAttribute('jsx-needs-render');",
+                "  thisScript.removeAttribute('data-needs-render');",
                 "})();",
             ]
         )
@@ -168,7 +168,7 @@ class JSXTag:
         return Tag(
             "script",
             type="text/javascript",
-            jsx_needs_render=True,
+            data_needs_render=True,
             children=[
                 HTML("\n" + js + "\n"),
                 _lib_dependency("react", script={"src": "react.production.min.js"}),

--- a/tests/test_jsx_tags.py
+++ b/tests/test_jsx_tags.py
@@ -19,16 +19,16 @@ def test_jsx_tags():
             <script src="lib/react-dom-%s/react-dom.production.min.js"></script>
           </head>
           <body>
-            <script type="text/javascript" jsx-needs-render="">
+            <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
             React.createElement(Foo)
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>
           </body>
@@ -47,7 +47,7 @@ def test_jsx_tags():
             <script src="lib/react-dom-%s/react-dom.production.min.js"></script>
           </head>
           <body>
-            <script type="text/javascript" jsx-needs-render="">
+            <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
@@ -56,10 +56,10 @@ def test_jsx_tags():
               React.createElement(Bar)
             )
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>
           </body>
@@ -84,7 +84,7 @@ def test_jsx_tags():
     )
     assert str(x) == textwrap.dedent(
         """\
-        <script type="text/javascript" jsx-needs-render="">
+        <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
@@ -108,10 +108,10 @@ def test_jsx_tags():
               )
             )
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>"""
     )
@@ -125,7 +125,7 @@ def test_jsx_tags():
     )
     assert str(x) == textwrap.dedent(
         """\
-        <script type="text/javascript" jsx-needs-render="">
+        <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
@@ -138,10 +138,10 @@ def test_jsx_tags():
               )
             )
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>"""
     )
@@ -151,7 +151,7 @@ def test_jsx_tags():
     )
     assert str(x) == textwrap.dedent(
         """\
-        <script type="text/javascript" jsx-needs-render="">
+        <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
@@ -159,10 +159,10 @@ def test_jsx_tags():
               Foo, {"htmlTag": [React.createElement('div'), React.createElement(
           'div', {"foo": "1"})]})
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>"""
     )
@@ -174,7 +174,7 @@ def test_jsx_tags():
     )
     assert str(x) == textwrap.dedent(
         """\
-        <script type="text/javascript" jsx-needs-render="">
+        <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
@@ -184,10 +184,10 @@ def test_jsx_tags():
                 'div', {"style": {"color": "red"}})
             )
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>"""
     )
@@ -227,7 +227,7 @@ def test_jsx_tagifiable_children():
 
     assert str(x) == textwrap.dedent(
         """\
-        <script type="text/javascript" jsx-needs-render="">
+        <script type="text/javascript" data-needs-render="">
         (function() {
           var container = new DocumentFragment();
           ReactDOM.render(
@@ -246,10 +246,10 @@ def test_jsx_tagifiable_children():
               )
             )
           , container);
-          var thisScript = document.querySelector('script[jsx-needs-render]');
+          var thisScript = document.querySelector('script[data-needs-render]');
           if (!thisScript) throw new Error('Failed to render JSXTag("Foo")');
           thisScript.after(container);
-          thisScript.removeAttribute('jsx-needs-render');
+          thisScript.removeAttribute('data-needs-render');
         })();
         </script>"""
     )


### PR DESCRIPTION
Closes #18 (and, as a consequence, closes https://github.com/rstudio/prism/issues/88)