### PR TITLE
Move requirements.txt to install_requires in setup.cfg

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,15 +21,15 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Install
+        run: |
+          make install
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Install
-        run: |
-          make install
       - name: Run unit tests
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -81,5 +81,5 @@ dist: clean ## builds source and wheel package
 	python3 setup.py bdist_wheel
 	ls -l dist
 
-install: clean ## install the package to the active Python's site-packages
-	python3 setup.py install
+install: dist ## install the package to the active Python's site-packages
+	python3 -m pip install --force-reinstall dist/htmltools*.whl

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-black==21.9b0
-flake8==3.9.2
-pytest==6.2.4
-pre-commit==2.15.0
-snapshottest==0.6.0
+black>=21.9b0
+flake8>=3.9.2
+pytest>=6.2.4
+pre-commit>=2.15.0
+snapshottest>=0.6.0
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-typing_extensions==3.10.0.0
-packaging==20.9
-ipython==7.31.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [flake8]
 ignore = E203, E302, E402, E501, F403, F405, W503
+
+[options]
+install_requires =
+    typing_extensions>=3.10.0.0
+    packaging>=20.9
+    ipython>=7.31.1


### PR DESCRIPTION
This should make it so installing the wheel will bring in dependencies automatically. It also changes `make install` to install via the wheel file, instead of running `setup.py`.

Related to: https://github.com/rstudio/prism/pull/111