### PR TITLE
Allow lib_prefix to be specified through an environment variable

### DIFF
--- a/htmltools/_util.py
+++ b/htmltools/_util.py
@@ -132,7 +132,7 @@ def hash_deterministic(s: str) -> str:
     """
     Returns a deterministic hash of the given string.
     """
-    return hashlib.sha1(s.encode('utf-8')).hexdigest()
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()
 
 
 class _HttpServerInfo(NamedTuple):
@@ -175,3 +175,11 @@ def get_open_port() -> int:
     with closing(socket()) as sock:
         sock.bind(("", 0))
         return sock.getsockname()[1]
+
+
+# Sentinel value - indicates a missing value in a function call.
+class MISSING_TYPE:
+    pass
+
+
+MISSING = MISSING_TYPE()

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -15,7 +15,7 @@ def test_dep_resolution():
     )
     c1_0 = HTMLDependency("c", "1.0", source={"subdir": "foo"}, script={"src": "c1.js"})
     test = TagList(a1_1, b1_9, b1_10, a1_2, a1_2_1, b1_9, b1_10, c1_0)
-    assert HTMLDocument(test).render(lib_prefix=None)["html"] == textwrap.dedent(
+    assert HTMLDocument(test).render(lib_prefix="")["html"] == textwrap.dedent(
         """\
         <!DOCTYPE html>
         <html>
@@ -57,9 +57,7 @@ def test_inline_deps(snapshot):
         TagList([a1_1, div("foo")], "bar"),
         div([a1_1, div("foo")], "bar"),
     ]
-    html_ = "\n\n".join(
-        [HTMLDocument(t).render(lib_prefix=None)["html"] for t in tests]
-    )
+    html_ = "\n\n".join([HTMLDocument(t).render(lib_prefix="")["html"] for t in tests])
     snapshot.assert_match(html_, "inline_deps")
 
 
@@ -86,16 +84,16 @@ def test_append_deps():
 
     x = div(a1_1, b1_0)
     x.append(a1_2)
-    assert HTMLDocument(x).render(lib_prefix=None)["html"] == expected_result
+    assert HTMLDocument(x).render(lib_prefix="")["html"] == expected_result
 
     y = div(a1_1)
     y.append([a1_2, b1_0])
-    assert HTMLDocument(y).render(lib_prefix=None)["html"] == expected_result
+    assert HTMLDocument(y).render(lib_prefix="")["html"] == expected_result
 
     z = div()
     z.append([a1_1, b1_0])
     z.append(a1_2)
-    assert HTMLDocument(z).render(lib_prefix=None)["html"] == expected_result
+    assert HTMLDocument(z).render(lib_prefix="")["html"] == expected_result
 
 
 def test_script_input():
@@ -213,7 +211,7 @@ def test_as_dict():
         stylesheet=[{"href": "b1.css"}, {"href": "b2.css"}],
         head=tags.script("1 && 1"),
     )
-    assert b.as_dict(lib_prefix=None) == {
+    assert b.as_dict(lib_prefix="") == {
         "name": "b",
         "version": "2.0",
         "script": [],

--- a/tests/test_html_document.py
+++ b/tests/test_html_document.py
@@ -140,7 +140,7 @@ def test_tagify_first():
     result = x.tagify().render()
     assert result["dependencies"] == [DelayedDep.dep]
 
-    result = HTMLDocument(x).render(lib_prefix=None)
+    result = HTMLDocument(x).render(lib_prefix="")
     assert result["dependencies"] == [DelayedDep.dep]
     assert result["html"].find('<script src="testdep-1.0/testdep.js">') != -1
     assert (

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -229,7 +229,7 @@ def test_html_save():
         stylesheet={"href": "testdep/testdep.css"},
         script={"src": "testdep/testdep.js"},
     )
-    assert saved_html(div("foo", dep), libdir=None) == textwrap.dedent(
+    assert saved_html(div("foo", dep), libdir="") == textwrap.dedent(
         """\
         <!DOCTYPE html>
         <html>


### PR DESCRIPTION
Currently, `shiny.App` allows you to set a `LIB_PREFIX` field to control the prefix added to rendered HTML dependencies. Unfortunately, this implies that, for statically rendered UI, there is no foolproof way to know where to request a dependency's files. I'll soon be opening a shiny PR where this is relevant.

TODO: unit test and document