### PR TITLE
Don't produce interior whitespace within a tag that has inline tag(s)

### DIFF
--- a/tests/test_html_document.py
+++ b/tests/test_html_document.py
@@ -105,10 +105,7 @@ def test_html_document_head_hoisting():
             <script>alert('2')</script>
           </head>
           <body>
-            <div>
-              Hello,
-              <span>world</span>
-            </div>
+            <div>Hello,<span>world</span></div>
           </body>
         </html>"""
     )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -159,24 +159,13 @@ def test_tag_writing():
     expect_html(TagList("hi"), "hi")
     expect_html(TagList("one", "two", TagList("three")), "one\ntwo\nthree")
     expect_html(tags.b("one"), "<b>one</b>")
-    expect_html(tags.b("one", "two"), "<b>\n  one\n  two\n</b>")
+    expect_html(tags.b("one", "two"), "<b>onetwo</b>")
     expect_html(TagList(["one"]), "one")
     expect_html(TagList([TagList("one")]), "one")
     expect_html(TagList(tags.br(), "one"), "<br/>\none")
     assert str(
         tags.b("one", "two", span("foo", "bar", span("baz")))
-    ) == textwrap.dedent(
-        """\
-            <b>
-              one
-              two
-              <span>
-                foo
-                bar
-                <span>baz</span>
-              </span>
-            </b>"""
-    )
+    ) == textwrap.dedent("<b>onetwo<span>foobar<span>baz</span></span></b>")
     expect_html(tags.area(), "<area/>")
 
 
@@ -395,10 +384,7 @@ def test_tag_normalize_attr():
 def test_metadata_nodes_gone():
     # Make sure MetadataNodes don't result in a blank line.
     assert str(div(span("Body content"), head_content("abc"))) == textwrap.dedent(
-        """\
-        <div>
-          <span>Body content</span>
-        </div>"""
+        "<div><span>Body content</span></div>"
     )
 
     assert (

--- a/tests/test_tags_inline.py
+++ b/tests/test_tags_inline.py
@@ -1,0 +1,11 @@
+from htmltools import *
+
+
+def test_inline_link():
+    x = tags.p(
+        "Here is a paragraph with ", tags.a("a link", href="http://example.com"), "."
+    )
+    assert (
+        str(x)
+        == '<p>Here is a paragraph with <a href="http://example.com">a link</a>.</p>'
+    )


### PR DESCRIPTION
Closes #1

Also, now if you try to create void tag with children, you'll get an error [since the HTML spec doesn't allow for that](https://html.spec.whatwg.org/multipage/syntax.html#void-elements)

## TODO

- [ ] more unit tests