### PR TITLE
Pinned importlib_metadata to smaller than 5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest>=6.2.4
 pre-commit>=2.15.0
 snapshottest>=0.6.0
 wheel
+importlib-metadata>=1.1.0,<5;python_version<'3.8'


### PR DESCRIPTION
See https://github.com/rstudio/py-shiny/issues/348