### PR TITLE
Fix broken deserialization of deps

### DIFF
--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -1146,9 +1146,7 @@ class HTMLTextDocument:
     ) -> tuple[str, list[HTMLDependency]]:
         # Scan for HTML dependencies that were serialized via
         # HTMLdependency.get_tag_representation()
-        pattern = (
-            r'<script type="application/json" data-html-dependency="">(.*?)</script>'
-        )
+        pattern = r'<script type="application/json" data-html-dependency="">((?:.|\r|\n)*?)</script>'
         dep_strs = re.findall(pattern, html)
         # html = re.sub(pattern, "", html)
 
@@ -1446,7 +1444,7 @@ class HTMLDependency(MetadataNode):
         scripts = [Tag("script", **s) for s in d["script"]]
         return TagList(*metas, *links, *scripts, self.head)
 
-    def serialize_to_script_json(self, indent: int = 0, eol: str = "\n") -> Tag:
+    def serialize_to_script_json(self, indent: int | None = None) -> Tag:
         res = {
             "name": self.name,
             "version": str(self.version),

--- a/tests/test_html_document.py
+++ b/tests/test_html_document.py
@@ -3,6 +3,7 @@ import textwrap
 from tempfile import TemporaryDirectory
 from typing import Union
 
+import htmltools as ht
 from htmltools import (
     HTMLDependency,
     HTMLDocument,
@@ -263,3 +264,41 @@ def test_tagify_first():
         testdep_files = os.listdir(os.path.join(tmpdir, "mylib", "testdep"))
         testdep_files.sort()
         assert testdep_files == ["testdep.css", "testdep.js"]
+
+
+def test_json_roundtrip():
+    testdep = HTMLDependency(
+        "testdep",
+        "1.0",
+        source={"package": "htmltools", "subdir": "libtest/testdep"},
+        script={"src": "testdep.js"},
+        stylesheet={"href": "testdep.css"},
+    )
+    testdep2 = HTMLDependency(
+        "testdep2",
+        "1.0",
+        source={"package": "htmltools", "subdir": "libtest/testdep"},
+        script={"src": "testdep.js"},
+        stylesheet={"href": "testdep.css"},
+    )
+
+    old_mode = ht.html_dependency_render_mode
+    ht.html_dependency_render_mode = "json"
+    try:
+        x = ht.TagList(
+            [
+                ht.HTML('<meta data-foo="">'),
+                div("hello world", testdep),
+                # Also make sure it would work even with indents
+                ht.HTML(testdep2.serialize_to_script_json(indent=2)),
+            ]
+        )
+        x_str = str(x)
+        rendered = ht.HTMLTextDocument(
+            x_str, deps_replace_pattern='<meta data-foo="">'
+        ).render()
+        assert "testdep" in [d.name for d in rendered["dependencies"]]
+        assert "testdep2" in [d.name for d in rendered["dependencies"]]
+
+    finally:
+        ht.html_dependency_render_mode = old_mode


### PR DESCRIPTION
The previous implementation of deserialization of deps was broken if the JSON contained newlines. This commit both makes the deserialization robust to newlines, and also removes the newlines.

## Testing notes

Without this fix, [this qmd](https://github.com/jjallaire/penguins-dashboard/blob/main/penguins.qmd)'s Data tab comes up blank.

I added unit tests that verify the fixed deserialization both with and without newlines/indents.