### PR TITLE
Change type annotation of `_add_ws`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [UNRELEASED]
+
+* Changed the type annotation of `_add_ws` from `bool` to `TagAttrValue`. This makes it easier to write functions which call `Tag` functions and pass along `**kwargs`. (#67)
+
+
 ## [0.4.1] 2023-10-30
 
 * Fixed deserialization of JSON HTML dependencies when they contained newline characters. (#65)

--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.1.9000"
 
 from . import svg, tags
 from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport]  # noqa: F401

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -472,7 +472,8 @@ class Tag:
     *args
         Children for the tag.
     _add_ws
-        Whether to add whitespace surrounding the tag (see Note for details).
+        A ``bool`` indicating whether to add whitespace surrounding the tag (see Note
+        for details).
     **kwargs
         Attributes for the tag.
 
@@ -522,10 +523,18 @@ class Tag:
         self,
         _name: str,
         *args: TagChild | TagAttrs,
-        _add_ws: bool = True,
+        _add_ws: TagAttrValue = True,
         **kwargs: TagAttrValue,
     ) -> None:
         self.name = _name
+
+        # Note that _add_ws is marked as a TagAttrValue for the sake of static type
+        # checking, but it must in fact be a bool. This is due to limitations in
+        # Python's type system when passing along **kwargs.
+        # https://github.com/posit-dev/py-shiny/issues/609
+        if not isinstance(_add_ws, bool):
+            raise TypeError("`_add_ws` must be `True` or `False`")
+
         self.add_ws = _add_ws
 
         attrs = [x for x in args if isinstance(x, dict)]

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -531,7 +531,7 @@ class Tag:
         # Note that _add_ws is marked as a TagAttrValue for the sake of static type
         # checking, but it must in fact be a bool. This is due to limitations in
         # Python's type system when passing along **kwargs.
-        # https://github.com/posit-dev/py-shiny/issues/609
+        # https://github.com/posit-dev/py-htmltools/pull/67
         if not isinstance(_add_ws, bool):
             raise TypeError("`_add_ws` must be `True` or `False`")
 

--- a/htmltools/svg.py
+++ b/htmltools/svg.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from ._core import Tag, TagAttrs, TagAttrValue, TagChild
 
 
-def a(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def a(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <a> tag.
 
@@ -21,7 +21,7 @@ def a(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -38,7 +38,7 @@ def a(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("a", *args, _add_ws=_add_ws, **kwargs)
 
 
-def animate(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def animate(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <animate> tag.
 
@@ -49,7 +49,7 @@ def animate(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -66,7 +66,7 @@ def animate(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("animate", *args, _add_ws=_add_ws, **kwargs)
 
 
-def animateMotion(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def animateMotion(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <animateMotion> tag.
 
@@ -77,7 +77,7 @@ def animateMotion(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Ta
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -94,7 +94,7 @@ def animateMotion(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Ta
     return Tag("animateMotion", *args, _add_ws=_add_ws, **kwargs)
 
 
-def animateTransform(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def animateTransform(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <animateTransform> tag.
 
@@ -105,7 +105,7 @@ def animateTransform(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs:
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -122,7 +122,7 @@ def animateTransform(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs:
     return Tag("animateTransform", *args, _add_ws=_add_ws, **kwargs)
 
 
-def circle(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def circle(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <circle> tag.
 
@@ -133,7 +133,7 @@ def circle(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -150,7 +150,7 @@ def circle(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("circle", *args, _add_ws=_add_ws, **kwargs)
 
 
-def clipPath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def clipPath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <clipPath> tag.
 
@@ -161,7 +161,7 @@ def clipPath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -178,7 +178,7 @@ def clipPath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("clipPath", *args, _add_ws=_add_ws, **kwargs)
 
 
-def defs(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def defs(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <defs> tag.
 
@@ -189,7 +189,7 @@ def defs(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -206,7 +206,7 @@ def defs(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("defs", *args, _add_ws=_add_ws, **kwargs)
 
 
-def desc(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def desc(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <desc> tag.
 
@@ -217,7 +217,7 @@ def desc(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -234,7 +234,7 @@ def desc(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("desc", *args, _add_ws=_add_ws, **kwargs)
 
 
-def discard(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def discard(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <discard> tag.
 
@@ -245,7 +245,7 @@ def discard(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -262,7 +262,7 @@ def discard(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("discard", *args, _add_ws=_add_ws, **kwargs)
 
 
-def ellipse(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def ellipse(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <ellipse> tag.
 
@@ -273,7 +273,7 @@ def ellipse(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -290,7 +290,7 @@ def ellipse(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("ellipse", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feBlend(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feBlend(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feBlend> tag.
 
@@ -301,7 +301,7 @@ def feBlend(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -318,7 +318,7 @@ def feBlend(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feBlend", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feColorMatrix(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feColorMatrix(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feColorMatrix> tag.
 
@@ -329,7 +329,7 @@ def feColorMatrix(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Ta
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -346,7 +346,7 @@ def feColorMatrix(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Ta
     return Tag("feColorMatrix", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feComponentTransfer(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feComponentTransfer(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feComponentTransfer> tag.
 
@@ -357,7 +357,7 @@ def feComponentTransfer(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwar
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -374,7 +374,7 @@ def feComponentTransfer(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwar
     return Tag("feComponentTransfer", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feComposite(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feComposite(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feComposite> tag.
 
@@ -385,7 +385,7 @@ def feComposite(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagA
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -402,7 +402,7 @@ def feComposite(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagA
     return Tag("feComposite", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feConvolveMatrix(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feConvolveMatrix(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feConvolveMatrix> tag.
 
@@ -413,7 +413,7 @@ def feConvolveMatrix(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs:
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -430,7 +430,7 @@ def feConvolveMatrix(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs:
     return Tag("feConvolveMatrix", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feDiffuseLighting(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feDiffuseLighting(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feDiffuseLighting> tag.
 
@@ -441,7 +441,7 @@ def feDiffuseLighting(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -458,7 +458,7 @@ def feDiffuseLighting(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs
     return Tag("feDiffuseLighting", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feDisplacementMap(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feDisplacementMap(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feDisplacementMap> tag.
 
@@ -469,7 +469,7 @@ def feDisplacementMap(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -486,7 +486,7 @@ def feDisplacementMap(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs
     return Tag("feDisplacementMap", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feDistantLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feDistantLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feDistantLight> tag.
 
@@ -497,7 +497,7 @@ def feDistantLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -514,7 +514,7 @@ def feDistantLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     return Tag("feDistantLight", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feDropShadow(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feDropShadow(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feDropShadow> tag.
 
@@ -525,7 +525,7 @@ def feDropShadow(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -542,7 +542,7 @@ def feDropShadow(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     return Tag("feDropShadow", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feFlood(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feFlood(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feFlood> tag.
 
@@ -553,7 +553,7 @@ def feFlood(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -570,7 +570,7 @@ def feFlood(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feFlood", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feFuncA(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feFuncA(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feFuncA> tag.
 
@@ -581,7 +581,7 @@ def feFuncA(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -598,7 +598,7 @@ def feFuncA(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feFuncA", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feFuncB(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feFuncB(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feFuncB> tag.
 
@@ -609,7 +609,7 @@ def feFuncB(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -626,7 +626,7 @@ def feFuncB(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feFuncB", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feFuncG(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feFuncG(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feFuncG> tag.
 
@@ -637,7 +637,7 @@ def feFuncG(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -654,7 +654,7 @@ def feFuncG(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feFuncG", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feFuncR(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feFuncR(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feFuncR> tag.
 
@@ -665,7 +665,7 @@ def feFuncR(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -682,7 +682,7 @@ def feFuncR(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feFuncR", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feGaussianBlur(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feGaussianBlur(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feGaussianBlur> tag.
 
@@ -693,7 +693,7 @@ def feGaussianBlur(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -710,7 +710,7 @@ def feGaussianBlur(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     return Tag("feGaussianBlur", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feImage(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feImage(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feImage> tag.
 
@@ -721,7 +721,7 @@ def feImage(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -738,7 +738,7 @@ def feImage(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feImage", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feMerge(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feMerge(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feMerge> tag.
 
@@ -749,7 +749,7 @@ def feMerge(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -766,7 +766,7 @@ def feMerge(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("feMerge", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feMergeNode(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feMergeNode(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feMergeNode> tag.
 
@@ -777,7 +777,7 @@ def feMergeNode(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagA
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -794,7 +794,7 @@ def feMergeNode(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagA
     return Tag("feMergeNode", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feMorphology(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feMorphology(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feMorphology> tag.
 
@@ -805,7 +805,7 @@ def feMorphology(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -822,7 +822,7 @@ def feMorphology(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     return Tag("feMorphology", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feOffset(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feOffset(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feOffset> tag.
 
@@ -833,7 +833,7 @@ def feOffset(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -850,7 +850,7 @@ def feOffset(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("feOffset", *args, _add_ws=_add_ws, **kwargs)
 
 
-def fePointLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def fePointLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <fePointLight> tag.
 
@@ -861,7 +861,7 @@ def fePointLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -878,7 +878,7 @@ def fePointLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     return Tag("fePointLight", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feSpecularLighting(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feSpecularLighting(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feSpecularLighting> tag.
 
@@ -889,7 +889,7 @@ def feSpecularLighting(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwarg
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -906,7 +906,7 @@ def feSpecularLighting(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwarg
     return Tag("feSpecularLighting", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feSpotLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feSpotLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feSpotLight> tag.
 
@@ -917,7 +917,7 @@ def feSpotLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagA
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -934,7 +934,7 @@ def feSpotLight(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagA
     return Tag("feSpotLight", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feTile(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feTile(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feTile> tag.
 
@@ -945,7 +945,7 @@ def feTile(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -962,7 +962,7 @@ def feTile(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("feTile", *args, _add_ws=_add_ws, **kwargs)
 
 
-def feTurbulence(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def feTurbulence(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <feTurbulence> tag.
 
@@ -973,7 +973,7 @@ def feTurbulence(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -990,7 +990,7 @@ def feTurbulence(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Tag
     return Tag("feTurbulence", *args, _add_ws=_add_ws, **kwargs)
 
 
-def filter(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def filter(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <filter> tag.
 
@@ -1001,7 +1001,7 @@ def filter(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1018,7 +1018,7 @@ def filter(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("filter", *args, _add_ws=_add_ws, **kwargs)
 
 
-def foreignObject(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def foreignObject(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <foreignObject> tag.
 
@@ -1029,7 +1029,7 @@ def foreignObject(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Ta
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1046,7 +1046,7 @@ def foreignObject(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: Ta
     return Tag("foreignObject", *args, _add_ws=_add_ws, **kwargs)
 
 
-def g(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def g(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <g> tag.
 
@@ -1057,7 +1057,7 @@ def g(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) 
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1074,7 +1074,7 @@ def g(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) 
     return Tag("g", *args, _add_ws=_add_ws, **kwargs)
 
 
-def hatch(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def hatch(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <hatch> tag.
 
@@ -1085,7 +1085,7 @@ def hatch(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1102,7 +1102,7 @@ def hatch(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("hatch", *args, _add_ws=_add_ws, **kwargs)
 
 
-def hatchpath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def hatchpath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <hatchpath> tag.
 
@@ -1113,7 +1113,7 @@ def hatchpath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAtt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1130,7 +1130,7 @@ def hatchpath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAtt
     return Tag("hatchpath", *args, _add_ws=_add_ws, **kwargs)
 
 
-def image(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def image(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <image> tag.
 
@@ -1141,7 +1141,7 @@ def image(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1158,7 +1158,7 @@ def image(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("image", *args, _add_ws=_add_ws, **kwargs)
 
 
-def line(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def line(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <line> tag.
 
@@ -1169,7 +1169,7 @@ def line(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1186,7 +1186,7 @@ def line(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("line", *args, _add_ws=_add_ws, **kwargs)
 
 
-def linearGradient(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def linearGradient(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <linearGradient> tag.
 
@@ -1197,7 +1197,7 @@ def linearGradient(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1214,7 +1214,7 @@ def linearGradient(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     return Tag("linearGradient", *args, _add_ws=_add_ws, **kwargs)
 
 
-def marker(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def marker(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <marker> tag.
 
@@ -1225,7 +1225,7 @@ def marker(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1242,7 +1242,7 @@ def marker(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("marker", *args, _add_ws=_add_ws, **kwargs)
 
 
-def mask(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def mask(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <mask> tag.
 
@@ -1253,7 +1253,7 @@ def mask(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1270,7 +1270,7 @@ def mask(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("mask", *args, _add_ws=_add_ws, **kwargs)
 
 
-def metadata(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def metadata(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <metadata> tag.
 
@@ -1281,7 +1281,7 @@ def metadata(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1298,7 +1298,7 @@ def metadata(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("metadata", *args, _add_ws=_add_ws, **kwargs)
 
 
-def mpath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def mpath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <mpath> tag.
 
@@ -1309,7 +1309,7 @@ def mpath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1326,7 +1326,7 @@ def mpath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("mpath", *args, _add_ws=_add_ws, **kwargs)
 
 
-def path(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def path(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <path> tag.
 
@@ -1337,7 +1337,7 @@ def path(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1354,7 +1354,7 @@ def path(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("path", *args, _add_ws=_add_ws, **kwargs)
 
 
-def pattern(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def pattern(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <pattern> tag.
 
@@ -1365,7 +1365,7 @@ def pattern(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1382,7 +1382,7 @@ def pattern(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("pattern", *args, _add_ws=_add_ws, **kwargs)
 
 
-def polygon(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def polygon(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <polygon> tag.
 
@@ -1393,7 +1393,7 @@ def polygon(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1410,7 +1410,7 @@ def polygon(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("polygon", *args, _add_ws=_add_ws, **kwargs)
 
 
-def polyline(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def polyline(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <polyline> tag.
 
@@ -1421,7 +1421,7 @@ def polyline(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1438,7 +1438,7 @@ def polyline(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("polyline", *args, _add_ws=_add_ws, **kwargs)
 
 
-def radialGradient(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def radialGradient(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <radialGradient> tag.
 
@@ -1449,7 +1449,7 @@ def radialGradient(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1466,7 +1466,7 @@ def radialGradient(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: T
     return Tag("radialGradient", *args, _add_ws=_add_ws, **kwargs)
 
 
-def rect(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def rect(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <rect> tag.
 
@@ -1477,7 +1477,7 @@ def rect(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1494,7 +1494,7 @@ def rect(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("rect", *args, _add_ws=_add_ws, **kwargs)
 
 
-def script(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def script(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <script> tag.
 
@@ -1505,7 +1505,7 @@ def script(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1522,7 +1522,7 @@ def script(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("script", *args, _add_ws=_add_ws, **kwargs)
 
 
-def set(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def set(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <set> tag.
 
@@ -1533,7 +1533,7 @@ def set(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1550,7 +1550,7 @@ def set(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     return Tag("set", *args, _add_ws=_add_ws, **kwargs)
 
 
-def stop(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def stop(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <stop> tag.
 
@@ -1561,7 +1561,7 @@ def stop(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1578,7 +1578,7 @@ def stop(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("stop", *args, _add_ws=_add_ws, **kwargs)
 
 
-def style(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def style(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <style> tag.
 
@@ -1589,7 +1589,7 @@ def style(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1606,7 +1606,7 @@ def style(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("style", *args, _add_ws=_add_ws, **kwargs)
 
 
-def svg(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def svg(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <svg> tag.
 
@@ -1617,7 +1617,7 @@ def svg(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1634,7 +1634,7 @@ def svg(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("svg", *args, _add_ws=_add_ws, **kwargs)
 
 
-def switch(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def switch(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <switch> tag.
 
@@ -1645,7 +1645,7 @@ def switch(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1662,7 +1662,7 @@ def switch(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("switch", *args, _add_ws=_add_ws, **kwargs)
 
 
-def symbol(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def symbol(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <symbol> tag.
 
@@ -1673,7 +1673,7 @@ def symbol(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1690,7 +1690,7 @@ def symbol(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("symbol", *args, _add_ws=_add_ws, **kwargs)
 
 
-def text(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def text(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <text> tag.
 
@@ -1701,7 +1701,7 @@ def text(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1718,7 +1718,7 @@ def text(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("text", *args, _add_ws=_add_ws, **kwargs)
 
 
-def textPath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def textPath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <textPath> tag.
 
@@ -1729,7 +1729,7 @@ def textPath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1746,7 +1746,7 @@ def textPath(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("textPath", *args, _add_ws=_add_ws, **kwargs)
 
 
-def title(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def title(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <title> tag.
 
@@ -1757,7 +1757,7 @@ def title(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1774,7 +1774,7 @@ def title(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("title", *args, _add_ws=_add_ws, **kwargs)
 
 
-def tspan(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def tspan(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <tspan> tag.
 
@@ -1785,7 +1785,7 @@ def tspan(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1802,7 +1802,7 @@ def tspan(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("tspan", *args, _add_ws=_add_ws, **kwargs)
 
 
-def use(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def use(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <use> tag.
 
@@ -1813,7 +1813,7 @@ def use(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1830,7 +1830,7 @@ def use(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     return Tag("use", *args, _add_ws=_add_ws, **kwargs)
 
 
-def view(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def view(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <view> tag.
 
@@ -1841,7 +1841,7 @@ def view(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 

--- a/htmltools/tags.py
+++ b/htmltools/tags.py
@@ -30,7 +30,7 @@ __all__ = (
 )
 
 
-def html(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def html(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <html> tag.
 
@@ -41,7 +41,7 @@ def html(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -58,7 +58,7 @@ def html(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("html", *args, _add_ws=_add_ws, **kwargs)
 
 
-def base(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def base(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <base> tag.
 
@@ -69,7 +69,7 @@ def base(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -86,7 +86,7 @@ def base(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("base", *args, _add_ws=_add_ws, **kwargs)
 
 
-def head(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def head(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <head> tag.
 
@@ -97,7 +97,7 @@ def head(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -114,7 +114,7 @@ def head(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("head", *args, _add_ws=_add_ws, **kwargs)
 
 
-def link(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def link(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <link> tag.
 
@@ -126,7 +126,7 @@ def link(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -143,7 +143,7 @@ def link(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("link", *args, _add_ws=_add_ws, **kwargs)
 
 
-def meta(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def meta(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <meta> tag.
 
@@ -154,7 +154,7 @@ def meta(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -171,7 +171,7 @@ def meta(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("meta", *args, _add_ws=_add_ws, **kwargs)
 
 
-def style(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def style(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <style> tag.
 
@@ -182,7 +182,7 @@ def style(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -199,7 +199,7 @@ def style(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("style", *args, _add_ws=_add_ws, **kwargs)
 
 
-def title(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def title(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <title> tag.
 
@@ -210,7 +210,7 @@ def title(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -227,7 +227,7 @@ def title(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("title", *args, _add_ws=_add_ws, **kwargs)
 
 
-def body(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def body(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <body> tag.
 
@@ -238,7 +238,7 @@ def body(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -255,7 +255,7 @@ def body(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("body", *args, _add_ws=_add_ws, **kwargs)
 
 
-def address(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def address(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <address> tag.
 
@@ -266,7 +266,7 @@ def address(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -283,7 +283,7 @@ def address(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("address", *args, _add_ws=_add_ws, **kwargs)
 
 
-def article(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def article(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <article> tag.
 
@@ -294,7 +294,7 @@ def article(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -311,7 +311,7 @@ def article(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("article", *args, _add_ws=_add_ws, **kwargs)
 
 
-def aside(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def aside(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <aside> tag.
 
@@ -322,7 +322,7 @@ def aside(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -339,7 +339,7 @@ def aside(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("aside", *args, _add_ws=_add_ws, **kwargs)
 
 
-def footer(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def footer(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <footer> tag.
 
@@ -350,7 +350,7 @@ def footer(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -367,7 +367,7 @@ def footer(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("footer", *args, _add_ws=_add_ws, **kwargs)
 
 
-def header(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def header(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <header> tag.
 
@@ -378,7 +378,7 @@ def header(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -395,7 +395,7 @@ def header(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("header", *args, _add_ws=_add_ws, **kwargs)
 
 
-def h1(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def h1(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <h1> tag.
 
@@ -406,7 +406,7 @@ def h1(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -423,7 +423,7 @@ def h1(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("h1", *args, _add_ws=_add_ws, **kwargs)
 
 
-def h2(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def h2(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <h2> tag.
 
@@ -434,7 +434,7 @@ def h2(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -451,7 +451,7 @@ def h2(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("h2", *args, _add_ws=_add_ws, **kwargs)
 
 
-def h3(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def h3(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <h3> tag.
 
@@ -462,7 +462,7 @@ def h3(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -479,7 +479,7 @@ def h3(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("h3", *args, _add_ws=_add_ws, **kwargs)
 
 
-def h4(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def h4(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <h4> tag.
 
@@ -490,7 +490,7 @@ def h4(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -507,7 +507,7 @@ def h4(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("h4", *args, _add_ws=_add_ws, **kwargs)
 
 
-def h5(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def h5(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <h5> tag.
 
@@ -518,7 +518,7 @@ def h5(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -535,7 +535,7 @@ def h5(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("h5", *args, _add_ws=_add_ws, **kwargs)
 
 
-def h6(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def h6(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <h6> tag.
 
@@ -546,7 +546,7 @@ def h6(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -563,7 +563,7 @@ def h6(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("h6", *args, _add_ws=_add_ws, **kwargs)
 
 
-def main(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def main(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <main> tag.
 
@@ -574,7 +574,7 @@ def main(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -591,7 +591,7 @@ def main(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("main", *args, _add_ws=_add_ws, **kwargs)
 
 
-def nav(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def nav(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <nav> tag.
 
@@ -602,7 +602,7 @@ def nav(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -619,7 +619,7 @@ def nav(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     return Tag("nav", *args, _add_ws=_add_ws, **kwargs)
 
 
-def section(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def section(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <section> tag.
 
@@ -630,7 +630,7 @@ def section(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -647,7 +647,7 @@ def section(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("section", *args, _add_ws=_add_ws, **kwargs)
 
 
-def blockquote(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def blockquote(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <blockquote> tag.
 
@@ -658,7 +658,7 @@ def blockquote(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -675,7 +675,7 @@ def blockquote(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAt
     return Tag("blockquote", *args, _add_ws=_add_ws, **kwargs)
 
 
-def dd(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def dd(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <dd> tag.
 
@@ -686,7 +686,7 @@ def dd(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -703,7 +703,7 @@ def dd(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("dd", *args, _add_ws=_add_ws, **kwargs)
 
 
-def div(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def div(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <div> tag.
 
@@ -714,7 +714,7 @@ def div(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -731,7 +731,7 @@ def div(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     return Tag("div", *args, _add_ws=_add_ws, **kwargs)
 
 
-def dl(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def dl(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <dl> tag.
 
@@ -742,7 +742,7 @@ def dl(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -759,7 +759,7 @@ def dl(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("dl", *args, _add_ws=_add_ws, **kwargs)
 
 
-def dt(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def dt(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <dt> tag.
 
@@ -770,7 +770,7 @@ def dt(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -787,7 +787,7 @@ def dt(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("dt", *args, _add_ws=_add_ws, **kwargs)
 
 
-def figcaption(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def figcaption(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <figcaption> tag.
 
@@ -798,7 +798,7 @@ def figcaption(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -815,7 +815,7 @@ def figcaption(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAt
     return Tag("figcaption", *args, _add_ws=_add_ws, **kwargs)
 
 
-def figure(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def figure(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <figure> tag.
 
@@ -826,7 +826,7 @@ def figure(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -843,7 +843,7 @@ def figure(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("figure", *args, _add_ws=_add_ws, **kwargs)
 
 
-def hr(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def hr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <hr> tag.
 
@@ -854,7 +854,7 @@ def hr(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -871,7 +871,7 @@ def hr(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("hr", *args, _add_ws=_add_ws, **kwargs)
 
 
-def li(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def li(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <li> tag.
 
@@ -882,7 +882,7 @@ def li(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -899,7 +899,7 @@ def li(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("li", *args, _add_ws=_add_ws, **kwargs)
 
 
-def menu(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def menu(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <menu> tag.
 
@@ -910,7 +910,7 @@ def menu(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -927,7 +927,7 @@ def menu(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("menu", *args, _add_ws=_add_ws, **kwargs)
 
 
-def ol(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def ol(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <ol> tag.
 
@@ -938,7 +938,7 @@ def ol(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -955,7 +955,7 @@ def ol(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("ol", *args, _add_ws=_add_ws, **kwargs)
 
 
-def p(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def p(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <p> tag.
 
@@ -966,7 +966,7 @@ def p(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) 
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -983,7 +983,7 @@ def p(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) 
     return Tag("p", *args, _add_ws=_add_ws, **kwargs)
 
 
-def pre(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def pre(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <pre> tag.
 
@@ -994,7 +994,7 @@ def pre(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1011,7 +1011,7 @@ def pre(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("pre", *args, _add_ws=_add_ws, **kwargs)
 
 
-def ul(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def ul(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <ul> tag.
 
@@ -1022,7 +1022,7 @@ def ul(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1039,7 +1039,7 @@ def ul(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("ul", *args, _add_ws=_add_ws, **kwargs)
 
 
-def a(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def a(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <a> tag.
 
@@ -1050,7 +1050,7 @@ def a(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1067,7 +1067,7 @@ def a(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("a", *args, _add_ws=_add_ws, **kwargs)
 
 
-def abbr(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def abbr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <abbr> tag.
 
@@ -1078,7 +1078,7 @@ def abbr(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1095,7 +1095,7 @@ def abbr(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("abbr", *args, _add_ws=_add_ws, **kwargs)
 
 
-def b(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def b(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <b> tag.
 
@@ -1106,7 +1106,7 @@ def b(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1123,7 +1123,7 @@ def b(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("b", *args, _add_ws=_add_ws, **kwargs)
 
 
-def bdi(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def bdi(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <bdi> tag.
 
@@ -1134,7 +1134,7 @@ def bdi(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1151,7 +1151,7 @@ def bdi(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("bdi", *args, _add_ws=_add_ws, **kwargs)
 
 
-def bdo(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def bdo(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <bdo> tag.
 
@@ -1162,7 +1162,7 @@ def bdo(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1179,7 +1179,7 @@ def bdo(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("bdo", *args, _add_ws=_add_ws, **kwargs)
 
 
-def br(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def br(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <br> tag.
 
@@ -1190,7 +1190,7 @@ def br(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1207,7 +1207,7 @@ def br(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue
     return Tag("br", *args, _add_ws=_add_ws, **kwargs)
 
 
-def cite(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def cite(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <cite> tag.
 
@@ -1218,7 +1218,7 @@ def cite(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1235,7 +1235,7 @@ def cite(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("cite", *args, _add_ws=_add_ws, **kwargs)
 
 
-def code(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def code(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <code> tag.
 
@@ -1246,7 +1246,7 @@ def code(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1263,7 +1263,7 @@ def code(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("code", *args, _add_ws=_add_ws, **kwargs)
 
 
-def data(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def data(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <data> tag.
 
@@ -1274,7 +1274,7 @@ def data(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1291,7 +1291,7 @@ def data(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("data", *args, _add_ws=_add_ws, **kwargs)
 
 
-def dfn(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def dfn(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <dfn> tag.
 
@@ -1302,7 +1302,7 @@ def dfn(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1319,7 +1319,7 @@ def dfn(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("dfn", *args, _add_ws=_add_ws, **kwargs)
 
 
-def em(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def em(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <em> tag.
 
@@ -1330,7 +1330,7 @@ def em(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1347,7 +1347,7 @@ def em(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue
     return Tag("em", *args, _add_ws=_add_ws, **kwargs)
 
 
-def i(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def i(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <i> tag.
 
@@ -1358,7 +1358,7 @@ def i(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1375,7 +1375,7 @@ def i(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("i", *args, _add_ws=_add_ws, **kwargs)
 
 
-def kbd(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def kbd(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <kbd> tag.
 
@@ -1386,7 +1386,7 @@ def kbd(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1403,7 +1403,7 @@ def kbd(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("kbd", *args, _add_ws=_add_ws, **kwargs)
 
 
-def mark(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def mark(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <mark> tag.
 
@@ -1414,7 +1414,7 @@ def mark(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1431,7 +1431,7 @@ def mark(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("mark", *args, _add_ws=_add_ws, **kwargs)
 
 
-def q(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def q(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <q> tag.
 
@@ -1442,7 +1442,7 @@ def q(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1459,7 +1459,7 @@ def q(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("q", *args, _add_ws=_add_ws, **kwargs)
 
 
-def rp(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def rp(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <rp> tag.
 
@@ -1470,7 +1470,7 @@ def rp(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1487,7 +1487,7 @@ def rp(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("rp", *args, _add_ws=_add_ws, **kwargs)
 
 
-def rt(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def rt(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <rt> tag.
 
@@ -1498,7 +1498,7 @@ def rt(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1515,7 +1515,7 @@ def rt(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("rt", *args, _add_ws=_add_ws, **kwargs)
 
 
-def ruby(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def ruby(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <ruby> tag.
 
@@ -1526,7 +1526,7 @@ def ruby(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1543,7 +1543,7 @@ def ruby(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("ruby", *args, _add_ws=_add_ws, **kwargs)
 
 
-def s(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def s(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <s> tag.
 
@@ -1554,7 +1554,7 @@ def s(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1571,7 +1571,7 @@ def s(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("s", *args, _add_ws=_add_ws, **kwargs)
 
 
-def samp(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def samp(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <samp> tag.
 
@@ -1582,7 +1582,7 @@ def samp(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1599,7 +1599,7 @@ def samp(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("samp", *args, _add_ws=_add_ws, **kwargs)
 
 
-def small(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def small(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <small> tag.
 
@@ -1610,7 +1610,7 @@ def small(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1627,7 +1627,7 @@ def small(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("small", *args, _add_ws=_add_ws, **kwargs)
 
 
-def span(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def span(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <span> tag.
 
@@ -1638,7 +1638,7 @@ def span(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1655,7 +1655,7 @@ def span(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("span", *args, _add_ws=_add_ws, **kwargs)
 
 
-def strong(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def strong(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <strong> tag.
 
@@ -1666,7 +1666,7 @@ def strong(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1683,7 +1683,7 @@ def strong(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("strong", *args, _add_ws=_add_ws, **kwargs)
 
 
-def sub(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def sub(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <sub> tag.
 
@@ -1694,7 +1694,7 @@ def sub(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1711,7 +1711,7 @@ def sub(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("sub", *args, _add_ws=_add_ws, **kwargs)
 
 
-def sup(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def sup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <sup> tag.
 
@@ -1722,7 +1722,7 @@ def sup(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1739,7 +1739,7 @@ def sup(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("sup", *args, _add_ws=_add_ws, **kwargs)
 
 
-def time(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def time(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <time> tag.
 
@@ -1750,7 +1750,7 @@ def time(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1767,7 +1767,7 @@ def time(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("time", *args, _add_ws=_add_ws, **kwargs)
 
 
-def u(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def u(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <u> tag.
 
@@ -1778,7 +1778,7 @@ def u(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1795,7 +1795,7 @@ def u(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue)
     return Tag("u", *args, _add_ws=_add_ws, **kwargs)
 
 
-def var(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def var(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <var> tag.
 
@@ -1806,7 +1806,7 @@ def var(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1823,7 +1823,7 @@ def var(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("var", *args, _add_ws=_add_ws, **kwargs)
 
 
-def wbr(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def wbr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <wbr> tag.
 
@@ -1834,7 +1834,7 @@ def wbr(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1851,7 +1851,7 @@ def wbr(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("wbr", *args, _add_ws=_add_ws, **kwargs)
 
 
-def area(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def area(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <area> tag.
 
@@ -1862,7 +1862,7 @@ def area(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1879,7 +1879,7 @@ def area(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("area", *args, _add_ws=_add_ws, **kwargs)
 
 
-def audio(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def audio(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <audio> tag.
 
@@ -1890,7 +1890,7 @@ def audio(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1907,7 +1907,7 @@ def audio(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("audio", *args, _add_ws=_add_ws, **kwargs)
 
 
-def img(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def img(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <img> tag.
 
@@ -1918,7 +1918,7 @@ def img(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1935,7 +1935,7 @@ def img(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("img", *args, _add_ws=_add_ws, **kwargs)
 
 
-def map(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def map(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <map> tag.
 
@@ -1946,7 +1946,7 @@ def map(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1963,7 +1963,7 @@ def map(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("map", *args, _add_ws=_add_ws, **kwargs)
 
 
-def track(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def track(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <track> tag.
 
@@ -1974,7 +1974,7 @@ def track(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -1991,7 +1991,7 @@ def track(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("track", *args, _add_ws=_add_ws, **kwargs)
 
 
-def video(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def video(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <video> tag.
 
@@ -2002,7 +2002,7 @@ def video(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2019,7 +2019,7 @@ def video(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("video", *args, _add_ws=_add_ws, **kwargs)
 
 
-def embed(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def embed(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <embed> tag.
 
@@ -2030,7 +2030,7 @@ def embed(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2047,7 +2047,7 @@ def embed(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("embed", *args, _add_ws=_add_ws, **kwargs)
 
 
-def iframe(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def iframe(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <iframe> tag.
 
@@ -2058,7 +2058,7 @@ def iframe(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2075,7 +2075,7 @@ def iframe(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("iframe", *args, _add_ws=_add_ws, **kwargs)
 
 
-def object(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def object(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <object> tag.
 
@@ -2086,7 +2086,7 @@ def object(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2103,7 +2103,7 @@ def object(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("object", *args, _add_ws=_add_ws, **kwargs)
 
 
-def param(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def param(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <param> tag.
 
@@ -2114,7 +2114,7 @@ def param(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2131,7 +2131,7 @@ def param(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("param", *args, _add_ws=_add_ws, **kwargs)
 
 
-def picture(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def picture(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <picture> tag.
 
@@ -2142,7 +2142,7 @@ def picture(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2159,7 +2159,7 @@ def picture(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttr
     return Tag("picture", *args, _add_ws=_add_ws, **kwargs)
 
 
-def portal(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def portal(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <portal> tag.
 
@@ -2170,7 +2170,7 @@ def portal(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2187,7 +2187,7 @@ def portal(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("portal", *args, _add_ws=_add_ws, **kwargs)
 
 
-def source(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def source(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <source> tag.
 
@@ -2198,7 +2198,7 @@ def source(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2215,7 +2215,7 @@ def source(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("source", *args, _add_ws=_add_ws, **kwargs)
 
 
-def svg(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def svg(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <svg> tag.
 
@@ -2230,7 +2230,7 @@ def svg(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2247,7 +2247,7 @@ def svg(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("svg", *args, _add_ws=_add_ws, **kwargs)
 
 
-def math(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def math(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <math> tag.
 
@@ -2262,7 +2262,7 @@ def math(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2279,7 +2279,7 @@ def math(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("math", *args, _add_ws=_add_ws, **kwargs)
 
 
-def canvas(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def canvas(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <canvas> tag.
 
@@ -2290,7 +2290,7 @@ def canvas(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2307,7 +2307,7 @@ def canvas(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("canvas", *args, _add_ws=_add_ws, **kwargs)
 
 
-def noscript(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def noscript(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <noscript> tag.
 
@@ -2318,7 +2318,7 @@ def noscript(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2335,7 +2335,7 @@ def noscript(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     return Tag("noscript", *args, _add_ws=_add_ws, **kwargs)
 
 
-def script(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def script(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <script> tag.
 
@@ -2346,7 +2346,7 @@ def script(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2363,7 +2363,7 @@ def script(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("script", *args, _add_ws=_add_ws, **kwargs)
 
 
-def ins(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def ins(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <ins> tag.
 
@@ -2374,7 +2374,7 @@ def ins(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2391,7 +2391,7 @@ def ins(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValu
     return Tag("ins", *args, _add_ws=_add_ws, **kwargs)
 
 
-def caption(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def caption(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <caption> tag.
 
@@ -2402,7 +2402,7 @@ def caption(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2419,7 +2419,7 @@ def caption(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("caption", *args, _add_ws=_add_ws, **kwargs)
 
 
-def col(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def col(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <col> tag.
 
@@ -2430,7 +2430,7 @@ def col(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2447,7 +2447,7 @@ def col(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue
     return Tag("col", *args, _add_ws=_add_ws, **kwargs)
 
 
-def colgroup(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def colgroup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <colgroup> tag.
 
@@ -2458,7 +2458,7 @@ def colgroup(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2475,7 +2475,7 @@ def colgroup(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("colgroup", *args, _add_ws=_add_ws, **kwargs)
 
 
-def table(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def table(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <table> tag.
 
@@ -2486,7 +2486,7 @@ def table(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2503,7 +2503,7 @@ def table(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("table", *args, _add_ws=_add_ws, **kwargs)
 
 
-def tbody(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def tbody(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <tbody> tag.
 
@@ -2514,7 +2514,7 @@ def tbody(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2531,7 +2531,7 @@ def tbody(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("tbody", *args, _add_ws=_add_ws, **kwargs)
 
 
-def td(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def td(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <td> tag.
 
@@ -2542,7 +2542,7 @@ def td(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2559,7 +2559,7 @@ def td(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("td", *args, _add_ws=_add_ws, **kwargs)
 
 
-def tfoot(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def tfoot(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <tfoot> tag.
 
@@ -2570,7 +2570,7 @@ def tfoot(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2587,7 +2587,7 @@ def tfoot(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("tfoot", *args, _add_ws=_add_ws, **kwargs)
 
 
-def th(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def th(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <th> tag.
 
@@ -2598,7 +2598,7 @@ def th(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2615,7 +2615,7 @@ def th(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("th", *args, _add_ws=_add_ws, **kwargs)
 
 
-def thead(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def thead(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <thead> tag.
 
@@ -2626,7 +2626,7 @@ def thead(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2643,7 +2643,7 @@ def thead(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVal
     return Tag("thead", *args, _add_ws=_add_ws, **kwargs)
 
 
-def tr(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def tr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <tr> tag.
 
@@ -2654,7 +2654,7 @@ def tr(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2671,7 +2671,7 @@ def tr(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue)
     return Tag("tr", *args, _add_ws=_add_ws, **kwargs)
 
 
-def button(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def button(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <button> tag.
 
@@ -2682,7 +2682,7 @@ def button(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2699,7 +2699,7 @@ def button(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("button", *args, _add_ws=_add_ws, **kwargs)
 
 
-def datalist(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def datalist(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <datalist> tag.
 
@@ -2710,7 +2710,7 @@ def datalist(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2727,7 +2727,7 @@ def datalist(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     return Tag("datalist", *args, _add_ws=_add_ws, **kwargs)
 
 
-def fieldset(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def fieldset(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <fieldset> tag.
 
@@ -2738,7 +2738,7 @@ def fieldset(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2755,7 +2755,7 @@ def fieldset(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("fieldset", *args, _add_ws=_add_ws, **kwargs)
 
 
-def form(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def form(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <form> tag.
 
@@ -2766,7 +2766,7 @@ def form(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2783,7 +2783,7 @@ def form(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValu
     return Tag("form", *args, _add_ws=_add_ws, **kwargs)
 
 
-def input(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def input(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <input> tag.
 
@@ -2794,7 +2794,7 @@ def input(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2811,7 +2811,7 @@ def input(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("input", *args, _add_ws=_add_ws, **kwargs)
 
 
-def label(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def label(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <label> tag.
 
@@ -2822,7 +2822,7 @@ def label(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2839,7 +2839,7 @@ def label(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("label", *args, _add_ws=_add_ws, **kwargs)
 
 
-def legend(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def legend(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <legend> tag.
 
@@ -2850,7 +2850,7 @@ def legend(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2867,7 +2867,7 @@ def legend(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("legend", *args, _add_ws=_add_ws, **kwargs)
 
 
-def meter(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def meter(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <meter> tag.
 
@@ -2878,7 +2878,7 @@ def meter(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2895,7 +2895,7 @@ def meter(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVa
     return Tag("meter", *args, _add_ws=_add_ws, **kwargs)
 
 
-def optgroup(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def optgroup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <optgroup> tag.
 
@@ -2906,7 +2906,7 @@ def optgroup(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2923,7 +2923,7 @@ def optgroup(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttr
     return Tag("optgroup", *args, _add_ws=_add_ws, **kwargs)
 
 
-def option(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def option(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <option> tag.
 
@@ -2934,7 +2934,7 @@ def option(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2951,7 +2951,7 @@ def option(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("option", *args, _add_ws=_add_ws, **kwargs)
 
 
-def output(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def output(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <output> tag.
 
@@ -2962,7 +2962,7 @@ def output(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -2979,7 +2979,7 @@ def output(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("output", *args, _add_ws=_add_ws, **kwargs)
 
 
-def progress(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def progress(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <progress> tag.
 
@@ -2990,7 +2990,7 @@ def progress(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3007,7 +3007,7 @@ def progress(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     return Tag("progress", *args, _add_ws=_add_ws, **kwargs)
 
 
-def select(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def select(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <select> tag.
 
@@ -3018,7 +3018,7 @@ def select(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3035,7 +3035,7 @@ def select(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrV
     return Tag("select", *args, _add_ws=_add_ws, **kwargs)
 
 
-def textarea(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def textarea(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <textarea> tag.
 
@@ -3046,7 +3046,7 @@ def textarea(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3063,7 +3063,7 @@ def textarea(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     return Tag("textarea", *args, _add_ws=_add_ws, **kwargs)
 
 
-def details(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def details(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <details> tag.
 
@@ -3074,7 +3074,7 @@ def details(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3091,7 +3091,7 @@ def details(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("details", *args, _add_ws=_add_ws, **kwargs)
 
 
-def dialog(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def dialog(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <dialog> tag.
 
@@ -3102,7 +3102,7 @@ def dialog(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3119,7 +3119,7 @@ def dialog(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrVa
     return Tag("dialog", *args, _add_ws=_add_ws, **kwargs)
 
 
-def summary(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrValue) -> Tag:
+def summary(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <summary> tag.
 
@@ -3130,7 +3130,7 @@ def summary(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3147,7 +3147,7 @@ def summary(*args: TagChild | TagAttrs, _add_ws: bool = True, **kwargs: TagAttrV
     return Tag("summary", *args, _add_ws=_add_ws, **kwargs)
 
 
-def slot(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def slot(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <slot> tag.
 
@@ -3158,7 +3158,7 @@ def slot(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 
@@ -3175,7 +3175,7 @@ def slot(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrVal
     return Tag("slot", *args, _add_ws=_add_ws, **kwargs)
 
 
-def template(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAttrValue) -> Tag:
+def template(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <template> tag.
 
@@ -3186,7 +3186,7 @@ def template(*args: TagChild | TagAttrs, _add_ws: bool = False, **kwargs: TagAtt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 

--- a/scripts/generate_tags.py
+++ b/scripts/generate_tags.py
@@ -73,7 +73,7 @@ _INLINE_TAG_NAMES = {
 
 
 tag_template = '''
-def {name}(*args: TagChild | TagAttrs, _add_ws: bool = {add_ws}, **kwargs: TagAttrValue) -> Tag:
+def {name}(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = {add_ws}, **kwargs: TagAttrValue) -> Tag:
     """
     Create a <{name}> tag.
 
@@ -84,7 +84,7 @@ def {name}(*args: TagChild | TagAttrs, _add_ws: bool = {add_ws}, **kwargs: TagAt
     *args
         Child elements to this tag.
     _add_ws
-        Whether whitespace should be added around this tag.
+        A bool indicating whether whitespace should be added around this tag.
     **kwargs
         Attributes to this tag.
 


### PR DESCRIPTION
This PR changes the type annotation of `_add_ws` from `bool` to `TagAttrValue`. Even though the value must still actually be a `bool`, this change simplifies writing functions that pass along `kwargs`.

For example, previously pyright would flag this as an error, because the `kwargs` could include `_add_ws`, but the former is a `TagAttrValue` while the latter is a `bool`:

```py
def my_component(*args: TagChild, **kwargs: TagAttrValue) -> Tag:
    return div("Hello", *args, **kwargs)
```

In order to satisfy the type checker, you previously would have to write this:

```py
def my_component(*args: TagChild, _add_ws: bool: True, **kwargs: TagAttrValue) -> Tag:
    return div("Hello", *args, _add_ws=_add_ws, **kwargs)
```


After this PR, the first version of the code is not flagged as an error by the type checker. If a non-bool is passed to `_add_ws`, there will be a run-time error.