### PR TITLE
Allow objects with a `_repr_html_()` method to be rendered to HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+* Objects with a `_repr_html_` method can now appear as children of `Tag`/`TagList` objects. (#74)
+
 * Changed the type annotation of `_add_ws` from `bool` to `TagAttrValue`. This makes it easier to write functions which call `Tag` functions and pass along `**kwargs`. (#67)
 
 * Changed the type annotation of `collapse_` from `str` to `str | float | None`. This makes it easier to write calls to `css()` pass along `**kwargs`. (#68)

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -317,19 +317,24 @@ class TagList(List[TagNode]):
 
                 prev_was_add_ws = child.add_ws
 
+            elif isinstance(child, ReprHtml):
+                if prev_was_add_ws:
+                    html_ += "  " * indent
+
+                html_ += child._repr_html_()  # type: ignore
+
+                prev_was_add_ws = False
+
             elif isinstance(child, Tagifiable):
                 raise RuntimeError(
                     "Encountered a non-tagified object. x.tagify() must be called before x.render()"
                 )
 
             else:
+                # If we get here, x must be a string.
                 if prev_was_add_ws:
                     html_ += "  " * indent
 
-                if isinstance(child, ReprHtml):
-                    child = HTML(child._repr_html_())  # type: ignore
-
-                # At this point, child must be a string/HTML.
                 if _escape_strings:
                     html_ += _normalize_text(child)
                 else:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,6 +5,5 @@
         "htmltools/",
         "examples/",
     ],
-    "reportImportCycles": false,
-    "reportPrivateUsage": "none",
+    "reportImportCycles": false
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,5 +5,6 @@
         "htmltools/",
         "examples/",
     ],
-    "reportImportCycles": false
+    "reportImportCycles": false,
+    "reportPrivateUsage": "none",
 }

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -741,6 +741,7 @@ def test_repr_html():
 
     f = Foo()
     assert str(TagList(f)) == "<span>Foo</span>"
+    assert str(span(f)) == "<span><span>Foo</span></span>"
     assert str(div(f)) == textwrap.dedent(
         """\
         <div>

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -733,6 +733,22 @@ def test_metadata_nodes_gone():
     )
 
 
+def test_repr_html():
+    # Make sure that objects with a __repr_html__ method are rendered as HTML.
+    class Foo:
+        def _repr_html_(self) -> str:
+            return "<span>Foo</span>"
+
+    f = Foo()
+    assert str(TagList(f)) == "<span>Foo</span>"
+    assert str(div(f)) == textwrap.dedent(
+        """\
+        <div>
+          <span>Foo</span>
+        </div>"""
+    )
+
+
 def test_types():
     # When a type checker like pyright is run on this file, this line will make sure
     # that a Tag function like `div()` matches the signature of the TagFunction Protocol


### PR DESCRIPTION
As we've pointed out in several py-shiny/py-shinywidget issues (e.g., https://github.com/posit-dev/py-shiny/issues/303), rendering "ad hoc (i.e., non-ipywidget) widgets"  like [folium](https://python-visualization.github.io/folium/latest/) or [itables](https://mwouts.github.io/itables/quick_start.html) is possible, but it isn't easy since to do because you need `ui.HTML(x._repr_html_())` to get the relevant HTML.

This PR makes it so objects that implement a [`_repr_html_`](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display) method are renderable when they appear as a child of a `Tag`/`TagList`. Also note that, using this approach, we can statically and dynamically render these objects:


```python
import folium

from shiny import App, render, ui

app_ui = ui.page_fixed(
    "Map 1",
    folium.Map(location=(45.5236, -122.6750)),
    ui.br(),
    "Map 2",
    ui.output_ui("map")
)

def server(input, output, session):
    @output
    @render.ui
    def map():
        return folium.Map(location=(45.5236, -122.6750))

app = App(app_ui, server)
```

