### PR TITLE
Add `wrap_displayhook_handler`

### DIFF
--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0.9001"
+__version__ = "0.5.0.9002"
 
 from . import svg, tags
 from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport]  # noqa: F401
@@ -19,6 +19,7 @@ from ._core import (
     TagList,
     TagNode,
     head_content,
+    wrap_displayhook_handler,
 )
 from ._util import css, html_escape
 from .tags import (
@@ -59,6 +60,7 @@ __all__ = (
     "TagList",
     "TagNode",
     "head_content",
+    "wrap_displayhook_handler",
     "css",
     "html_escape",
     "a",

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -913,13 +913,8 @@ def wrap_displayhook_handler(
             handler(value)
         elif hasattr(value, "_repr_html_"):
             handler(HTML(value._repr_html_()))  # pyright: ignore
-        else:
-            # We should NOT end up here for objects that were `def`ed, because they
-            # would already have been filtered out by _display_decorator_function_def().
-            # This is only for other kinds of expressions, the kind which would normally
-            # be printed at the console.
-            if value not in (None, ...):
-                handler(value)
+        elif value not in (None, ...):
+            handler(value)
 
     return handler_wrapper
 

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -63,6 +63,7 @@ __all__ = (
     "TagFunction",
     "Tagifiable",
     "head_content",
+    "wrap_displayhook_handler",
 )
 
 
@@ -579,15 +580,16 @@ class Tag:
                 "Attempted to enter a Tag object's context manager, but it has already been entered."
             )
         self.prev_displayhook = sys.displayhook
-        sys.displayhook = self._displayhook
+        sys.displayhook = wrap_displayhook_handler(
+            # self.append takes a TagChild, but the wrapper expects a function that
+            # takes a object.
+            self.append  # pyright: ignore[reportGeneralTypeIssues]
+        )
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         # If we got here, then self.prev_displayhook must be not None.
         sys.displayhook = cast(Callable[[object], None], self.prev_displayhook)
         sys.displayhook(self)
-
-    def _displayhook(self, x: object) -> None:
-        self.append(cast(TagChild, x))
 
     def insert(self, index: SupportsIndex, x: TagChild) -> None:
         """
@@ -893,6 +895,33 @@ def _render_tag_or_taglist(x: Tag | TagList) -> str:
         res += "\n".join(dep_html)
 
     return str(res)
+
+
+def wrap_displayhook_handler(
+    handler: Callable[[object], None]
+) -> Callable[[object], None]:
+    """
+    Wrap a displayhook function to handle different types of input objects
+
+    This function takes a function ``handler`` that would be used as a displayhook, and
+    returns a function which filters/transforms the input object depending on its type,
+    before passing it to ``handler()``.
+    """
+
+    def handler_wrapper(value: object) -> None:
+        if isinstance(value, (Tag, TagList, Tagifiable)):
+            handler(value)
+        elif hasattr(value, "_repr_html_"):
+            handler(HTML(value._repr_html_()))  # pyright: ignore
+        else:
+            # We should NOT end up here for objects that were `def`ed, because they
+            # would already have been filtered out by _display_decorator_function_def().
+            # This is only for other kinds of expressions, the kind which would normally
+            # be printed at the console.
+            if value not in (None, ...):
+                handler(value)
+
+    return handler_wrapper
 
 
 # =============================================================================


### PR DESCRIPTION
This PR adds a function `wrap_displayhook_handler()`, which is used in the `Tag.__enter__()` method, but can also be used in other packages.

The name isn't great -- I'm open to suggestions.