### PR TITLE
Add JS class

### DIFF
--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -5,6 +5,7 @@ from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport]  # noqa: F4
 from ._core import TagChildArg  # pyright: ignore[reportUnusedImport]  # noqa: F401
 from ._core import (
     HTML,
+    JS,
     HTMLDependency,
     HTMLDocument,
     HTMLTextDocument,
@@ -46,6 +47,7 @@ __all__ = (
     "svg",
     "tags",
     "HTML",
+    "JS",
     "HTMLDependency",
     "HTMLDocument",
     "HTMLTextDocument",

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -1238,7 +1238,31 @@ class HTMLTextDocument:
 # =============================================================================
 # HTML strings
 # =============================================================================
-class HTML(str):
+
+
+class RAW(str):
+    """
+    Base class for raw content.
+    """
+
+    def __str__(self) -> str:
+        return self.as_string()
+
+    def __add__(self, other: "str| RAW") -> str:
+        res = str.__add__(self, other)
+        return self.__class__(res) if isinstance(other, self.__class__) else res
+
+    def __repr__(self) -> str:
+        return self.as_string()
+
+    def _repr_html_(self) -> str:
+        return self.as_string()
+
+    def as_string(self) -> str:
+        return self + ""
+
+
+class HTML(RAW):
     """
     Mark a string as raw HTML. This will prevent the string from being escaped when
     rendered inside an HTML tag.
@@ -1252,22 +1276,15 @@ class HTML(str):
     <div><p>Hello</p></div>
     """
 
-    def __str__(self) -> str:
-        return self.as_string()
+    pass
 
-    # HTML() + HTML() should return HTML()
-    def __add__(self, other: "str| HTML") -> str:
-        res = str.__add__(self, other)
-        return HTML(res) if isinstance(other, HTML) else res
 
-    def __repr__(self) -> str:
-        return self.as_string()
+class JS(RAW):
+    """
+    Mark a string as raw JavaScript.
+    """
 
-    def _repr_html_(self) -> str:
-        return self.as_string()
-
-    def as_string(self) -> str:
-        return self + ""
+    pass
 
 
 # =============================================================================


### PR DESCRIPTION
This adds a JS class which we need for passing options to HTML tools. Since this class is currently identical to `HTML` I created a parent class `RAW` to hold that logic. I thought it was better to have `HTML` and `JS` as two child classes rather than as aliases in case we want to add HTML or JS specific methods (minify maybe?) down the road.