### PR TITLE
fix: Escape HTML tags in tag docstrings so they don't break our docs

### DIFF
--- a/htmltools/svg.py
+++ b/htmltools/svg.py
@@ -12,9 +12,9 @@ from ._core import Tag, TagAttrs, TagAttrValue, TagChild
 
 def a(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <a> tag.
+    Create a `<a>` tag.
 
-    Creates the <a> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a
+    Creates the `<a>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a
 
     Parameters
     ----------
@@ -40,9 +40,9 @@ def a(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def animate(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <animate> tag.
+    Create a `<animate>` tag.
 
-    Creates the <animate> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animate
+    Creates the `<animate>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animate
 
     Parameters
     ----------
@@ -68,9 +68,9 @@ def animate(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def animateMotion(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <animateMotion> tag.
+    Create a `<animateMotion>` tag.
 
-    Creates the <animateMotion> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateMotion
+    Creates the `<animateMotion>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateMotion
 
     Parameters
     ----------
@@ -96,9 +96,9 @@ def animateMotion(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kw
 
 def animateTransform(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <animateTransform> tag.
+    Create a `<animateTransform>` tag.
 
-    Creates the <animateTransform> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateTransform
+    Creates the `<animateTransform>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateTransform
 
     Parameters
     ----------
@@ -124,9 +124,9 @@ def animateTransform(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, *
 
 def circle(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <circle> tag.
+    Create a `<circle>` tag.
 
-    Creates the <circle> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle
+    Creates the `<circle>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle
 
     Parameters
     ----------
@@ -152,9 +152,9 @@ def circle(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def clipPath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <clipPath> tag.
+    Create a `<clipPath>` tag.
 
-    Creates the <clipPath> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/clipPath
+    Creates the `<clipPath>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/clipPath
 
     Parameters
     ----------
@@ -180,9 +180,9 @@ def clipPath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def defs(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <defs> tag.
+    Create a `<defs>` tag.
 
-    Creates the <defs> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
+    Creates the `<defs>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
 
     Parameters
     ----------
@@ -208,9 +208,9 @@ def defs(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def desc(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <desc> tag.
+    Create a `<desc>` tag.
 
-    Creates the <desc> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc
+    Creates the `<desc>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc
 
     Parameters
     ----------
@@ -236,9 +236,9 @@ def desc(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def discard(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <discard> tag.
+    Create a `<discard>` tag.
 
-    Creates the <discard> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/discard
+    Creates the `<discard>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/discard
 
     Parameters
     ----------
@@ -264,9 +264,9 @@ def discard(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def ellipse(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <ellipse> tag.
+    Create a `<ellipse>` tag.
 
-    Creates the <ellipse> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/ellipse
+    Creates the `<ellipse>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/ellipse
 
     Parameters
     ----------
@@ -292,9 +292,9 @@ def ellipse(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feBlend(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feBlend> tag.
+    Create a `<feBlend>` tag.
 
-    Creates the <feBlend> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feBlend
+    Creates the `<feBlend>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feBlend
 
     Parameters
     ----------
@@ -320,9 +320,9 @@ def feBlend(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feColorMatrix(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feColorMatrix> tag.
+    Create a `<feColorMatrix>` tag.
 
-    Creates the <feColorMatrix> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feColorMatrix
+    Creates the `<feColorMatrix>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feColorMatrix
 
     Parameters
     ----------
@@ -348,9 +348,9 @@ def feColorMatrix(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kw
 
 def feComponentTransfer(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feComponentTransfer> tag.
+    Create a `<feComponentTransfer>` tag.
 
-    Creates the <feComponentTransfer> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feComponentTransfer
+    Creates the `<feComponentTransfer>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feComponentTransfer
 
     Parameters
     ----------
@@ -376,9 +376,9 @@ def feComponentTransfer(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True
 
 def feComposite(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feComposite> tag.
+    Create a `<feComposite>` tag.
 
-    Creates the <feComposite> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feComposite
+    Creates the `<feComposite>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feComposite
 
     Parameters
     ----------
@@ -404,9 +404,9 @@ def feComposite(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwar
 
 def feConvolveMatrix(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feConvolveMatrix> tag.
+    Create a `<feConvolveMatrix>` tag.
 
-    Creates the <feConvolveMatrix> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feConvolveMatrix
+    Creates the `<feConvolveMatrix>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feConvolveMatrix
 
     Parameters
     ----------
@@ -432,9 +432,9 @@ def feConvolveMatrix(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, *
 
 def feDiffuseLighting(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feDiffuseLighting> tag.
+    Create a `<feDiffuseLighting>` tag.
 
-    Creates the <feDiffuseLighting> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDiffuseLighting
+    Creates the `<feDiffuseLighting>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDiffuseLighting
 
     Parameters
     ----------
@@ -460,9 +460,9 @@ def feDiffuseLighting(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, 
 
 def feDisplacementMap(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feDisplacementMap> tag.
+    Create a `<feDisplacementMap>` tag.
 
-    Creates the <feDisplacementMap> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDisplacementMap
+    Creates the `<feDisplacementMap>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDisplacementMap
 
     Parameters
     ----------
@@ -488,9 +488,9 @@ def feDisplacementMap(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, 
 
 def feDistantLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feDistantLight> tag.
+    Create a `<feDistantLight>` tag.
 
-    Creates the <feDistantLight> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDistantLight
+    Creates the `<feDistantLight>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDistantLight
 
     Parameters
     ----------
@@ -516,9 +516,9 @@ def feDistantLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **k
 
 def feDropShadow(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feDropShadow> tag.
+    Create a `<feDropShadow>` tag.
 
-    Creates the <feDropShadow> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDropShadow
+    Creates the `<feDropShadow>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feDropShadow
 
     Parameters
     ----------
@@ -544,9 +544,9 @@ def feDropShadow(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwa
 
 def feFlood(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feFlood> tag.
+    Create a `<feFlood>` tag.
 
-    Creates the <feFlood> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFlood
+    Creates the `<feFlood>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFlood
 
     Parameters
     ----------
@@ -572,9 +572,9 @@ def feFlood(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feFuncA(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feFuncA> tag.
+    Create a `<feFuncA>` tag.
 
-    Creates the <feFuncA> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncA
+    Creates the `<feFuncA>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncA
 
     Parameters
     ----------
@@ -600,9 +600,9 @@ def feFuncA(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feFuncB(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feFuncB> tag.
+    Create a `<feFuncB>` tag.
 
-    Creates the <feFuncB> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncB
+    Creates the `<feFuncB>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncB
 
     Parameters
     ----------
@@ -628,9 +628,9 @@ def feFuncB(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feFuncG(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feFuncG> tag.
+    Create a `<feFuncG>` tag.
 
-    Creates the <feFuncG> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncG
+    Creates the `<feFuncG>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncG
 
     Parameters
     ----------
@@ -656,9 +656,9 @@ def feFuncG(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feFuncR(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feFuncR> tag.
+    Create a `<feFuncR>` tag.
 
-    Creates the <feFuncR> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncR
+    Creates the `<feFuncR>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feFuncR
 
     Parameters
     ----------
@@ -684,9 +684,9 @@ def feFuncR(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feGaussianBlur(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feGaussianBlur> tag.
+    Create a `<feGaussianBlur>` tag.
 
-    Creates the <feGaussianBlur> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feGaussianBlur
+    Creates the `<feGaussianBlur>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feGaussianBlur
 
     Parameters
     ----------
@@ -712,9 +712,9 @@ def feGaussianBlur(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **k
 
 def feImage(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feImage> tag.
+    Create a `<feImage>` tag.
 
-    Creates the <feImage> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feImage
+    Creates the `<feImage>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feImage
 
     Parameters
     ----------
@@ -740,9 +740,9 @@ def feImage(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feMerge(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feMerge> tag.
+    Create a `<feMerge>` tag.
 
-    Creates the <feMerge> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMerge
+    Creates the `<feMerge>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMerge
 
     Parameters
     ----------
@@ -768,9 +768,9 @@ def feMerge(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def feMergeNode(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feMergeNode> tag.
+    Create a `<feMergeNode>` tag.
 
-    Creates the <feMergeNode> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMergeNode
+    Creates the `<feMergeNode>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMergeNode
 
     Parameters
     ----------
@@ -796,9 +796,9 @@ def feMergeNode(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwar
 
 def feMorphology(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feMorphology> tag.
+    Create a `<feMorphology>` tag.
 
-    Creates the <feMorphology> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMorphology
+    Creates the `<feMorphology>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMorphology
 
     Parameters
     ----------
@@ -824,9 +824,9 @@ def feMorphology(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwa
 
 def feOffset(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feOffset> tag.
+    Create a `<feOffset>` tag.
 
-    Creates the <feOffset> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feOffset
+    Creates the `<feOffset>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feOffset
 
     Parameters
     ----------
@@ -852,9 +852,9 @@ def feOffset(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def fePointLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <fePointLight> tag.
+    Create a `<fePointLight>` tag.
 
-    Creates the <fePointLight> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/fePointLight
+    Creates the `<fePointLight>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/fePointLight
 
     Parameters
     ----------
@@ -880,9 +880,9 @@ def fePointLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwa
 
 def feSpecularLighting(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feSpecularLighting> tag.
+    Create a `<feSpecularLighting>` tag.
 
-    Creates the <feSpecularLighting> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feSpecularLighting
+    Creates the `<feSpecularLighting>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feSpecularLighting
 
     Parameters
     ----------
@@ -908,9 +908,9 @@ def feSpecularLighting(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True,
 
 def feSpotLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feSpotLight> tag.
+    Create a `<feSpotLight>` tag.
 
-    Creates the <feSpotLight> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feSpotLight
+    Creates the `<feSpotLight>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feSpotLight
 
     Parameters
     ----------
@@ -936,9 +936,9 @@ def feSpotLight(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwar
 
 def feTile(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feTile> tag.
+    Create a `<feTile>` tag.
 
-    Creates the <feTile> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feTile
+    Creates the `<feTile>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feTile
 
     Parameters
     ----------
@@ -964,9 +964,9 @@ def feTile(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def feTurbulence(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <feTurbulence> tag.
+    Create a `<feTurbulence>` tag.
 
-    Creates the <feTurbulence> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feTurbulence
+    Creates the `<feTurbulence>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feTurbulence
 
     Parameters
     ----------
@@ -992,9 +992,9 @@ def feTurbulence(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwa
 
 def filter(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <filter> tag.
+    Create a `<filter>` tag.
 
-    Creates the <filter> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/filter
+    Creates the `<filter>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/filter
 
     Parameters
     ----------
@@ -1020,9 +1020,9 @@ def filter(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def foreignObject(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <foreignObject> tag.
+    Create a `<foreignObject>` tag.
 
-    Creates the <foreignObject> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject
+    Creates the `<foreignObject>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject
 
     Parameters
     ----------
@@ -1048,9 +1048,9 @@ def foreignObject(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kw
 
 def g(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <g> tag.
+    Create a `<g>` tag.
 
-    Creates the <g> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+    Creates the `<g>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
 
     Parameters
     ----------
@@ -1076,9 +1076,9 @@ def g(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAtt
 
 def hatch(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <hatch> tag.
+    Create a `<hatch>` tag.
 
-    Creates the <hatch> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/hatch
+    Creates the `<hatch>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/hatch
 
     Parameters
     ----------
@@ -1104,9 +1104,9 @@ def hatch(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def hatchpath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <hatchpath> tag.
+    Create a `<hatchpath>` tag.
 
-    Creates the <hatchpath> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/hatchpath
+    Creates the `<hatchpath>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/hatchpath
 
     Parameters
     ----------
@@ -1132,9 +1132,9 @@ def hatchpath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs
 
 def image(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <image> tag.
+    Create a `<image>` tag.
 
-    Creates the <image> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image
+    Creates the `<image>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image
 
     Parameters
     ----------
@@ -1160,9 +1160,9 @@ def image(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def line(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <line> tag.
+    Create a `<line>` tag.
 
-    Creates the <line> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/line
+    Creates the `<line>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/line
 
     Parameters
     ----------
@@ -1188,9 +1188,9 @@ def line(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def linearGradient(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <linearGradient> tag.
+    Create a `<linearGradient>` tag.
 
-    Creates the <linearGradient> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient
+    Creates the `<linearGradient>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient
 
     Parameters
     ----------
@@ -1216,9 +1216,9 @@ def linearGradient(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **k
 
 def marker(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <marker> tag.
+    Create a `<marker>` tag.
 
-    Creates the <marker> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker
+    Creates the `<marker>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker
 
     Parameters
     ----------
@@ -1244,9 +1244,9 @@ def marker(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def mask(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <mask> tag.
+    Create a `<mask>` tag.
 
-    Creates the <mask> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask
+    Creates the `<mask>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask
 
     Parameters
     ----------
@@ -1272,9 +1272,9 @@ def mask(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def metadata(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <metadata> tag.
+    Create a `<metadata>` tag.
 
-    Creates the <metadata> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata
+    Creates the `<metadata>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata
 
     Parameters
     ----------
@@ -1300,9 +1300,9 @@ def metadata(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def mpath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <mpath> tag.
+    Create a `<mpath>` tag.
 
-    Creates the <mpath> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mpath
+    Creates the `<mpath>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mpath
 
     Parameters
     ----------
@@ -1328,9 +1328,9 @@ def mpath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def path(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <path> tag.
+    Create a `<path>` tag.
 
-    Creates the <path> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path
+    Creates the `<path>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path
 
     Parameters
     ----------
@@ -1356,9 +1356,9 @@ def path(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def pattern(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <pattern> tag.
+    Create a `<pattern>` tag.
 
-    Creates the <pattern> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/pattern
+    Creates the `<pattern>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/pattern
 
     Parameters
     ----------
@@ -1384,9 +1384,9 @@ def pattern(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def polygon(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <polygon> tag.
+    Create a `<polygon>` tag.
 
-    Creates the <polygon> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polygon
+    Creates the `<polygon>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polygon
 
     Parameters
     ----------
@@ -1412,9 +1412,9 @@ def polygon(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def polyline(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <polyline> tag.
+    Create a `<polyline>` tag.
 
-    Creates the <polyline> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polyline
+    Creates the `<polyline>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polyline
 
     Parameters
     ----------
@@ -1440,9 +1440,9 @@ def polyline(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def radialGradient(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <radialGradient> tag.
+    Create a `<radialGradient>` tag.
 
-    Creates the <radialGradient> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/radialGradient
+    Creates the `<radialGradient>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/radialGradient
 
     Parameters
     ----------
@@ -1468,9 +1468,9 @@ def radialGradient(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **k
 
 def rect(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <rect> tag.
+    Create a `<rect>` tag.
 
-    Creates the <rect> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect
+    Creates the `<rect>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect
 
     Parameters
     ----------
@@ -1496,9 +1496,9 @@ def rect(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def script(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <script> tag.
+    Create a `<script>` tag.
 
-    Creates the <script> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script
+    Creates the `<script>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script
 
     Parameters
     ----------
@@ -1524,9 +1524,9 @@ def script(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def set(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <set> tag.
+    Create a `<set>` tag.
 
-    Creates the <set> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/set
+    Creates the `<set>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/set
 
     Parameters
     ----------
@@ -1552,9 +1552,9 @@ def set(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagA
 
 def stop(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <stop> tag.
+    Create a `<stop>` tag.
 
-    Creates the <stop> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/stop
+    Creates the `<stop>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/stop
 
     Parameters
     ----------
@@ -1580,9 +1580,9 @@ def stop(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def style(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <style> tag.
+    Create a `<style>` tag.
 
-    Creates the <style> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/style
+    Creates the `<style>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/style
 
     Parameters
     ----------
@@ -1608,9 +1608,9 @@ def style(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def svg(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <svg> tag.
+    Create a `<svg>` tag.
 
-    Creates the <svg> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
+    Creates the `<svg>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
 
     Parameters
     ----------
@@ -1636,9 +1636,9 @@ def svg(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def switch(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <switch> tag.
+    Create a `<switch>` tag.
 
-    Creates the <switch> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch
+    Creates the `<switch>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch
 
     Parameters
     ----------
@@ -1664,9 +1664,9 @@ def switch(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def symbol(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <symbol> tag.
+    Create a `<symbol>` tag.
 
-    Creates the <symbol> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol
+    Creates the `<symbol>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol
 
     Parameters
     ----------
@@ -1692,9 +1692,9 @@ def symbol(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def text(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <text> tag.
+    Create a `<text>` tag.
 
-    Creates the <text> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text
+    Creates the `<text>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text
 
     Parameters
     ----------
@@ -1720,9 +1720,9 @@ def text(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def textPath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <textPath> tag.
+    Create a `<textPath>` tag.
 
-    Creates the <textPath> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/textPath
+    Creates the `<textPath>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/textPath
 
     Parameters
     ----------
@@ -1748,9 +1748,9 @@ def textPath(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def title(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <title> tag.
+    Create a `<title>` tag.
 
-    Creates the <title> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title
+    Creates the `<title>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title
 
     Parameters
     ----------
@@ -1776,9 +1776,9 @@ def title(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def tspan(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <tspan> tag.
+    Create a `<tspan>` tag.
 
-    Creates the <tspan> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/tspan
+    Creates the `<tspan>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/tspan
 
     Parameters
     ----------
@@ -1804,9 +1804,9 @@ def tspan(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def use(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <use> tag.
+    Create a `<use>` tag.
 
-    Creates the <use> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+    Creates the `<use>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
 
     Parameters
     ----------
@@ -1832,9 +1832,9 @@ def use(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagA
 
 def view(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <view> tag.
+    Create a `<view>` tag.
 
-    Creates the <view> SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/view
+    Creates the `<view>` SVG element. Learn more at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/view
 
     Parameters
     ----------

--- a/htmltools/tags.py
+++ b/htmltools/tags.py
@@ -32,9 +32,9 @@ __all__ = (
 
 def html(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <html> tag.
+    Create a `<html>` tag.
 
-    The <html> HTML element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html
+    The `<html>` HTML element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html
 
     Parameters
     ----------
@@ -60,9 +60,9 @@ def html(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def base(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <base> tag.
+    Create a `<base>` tag.
 
-    The <base> HTML element specifies the base URL to use for all relative URLs in a document. There can be only one <base> element in a document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+    The `<base>` HTML element specifies the base URL to use for all relative URLs in a document. There can be only one `<base>` element in a document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
     Parameters
     ----------
@@ -88,9 +88,9 @@ def base(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def head(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <head> tag.
+    Create a `<head>` tag.
 
-    The <head> HTML element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
+    The `<head>` HTML element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
 
     Parameters
     ----------
@@ -116,9 +116,9 @@ def head(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def link(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <link> tag.
+    Create a `<link>` tag.
 
-    The <link> HTML element specifies relationships between the current document and an external resource.
+    The `<link>` HTML element specifies relationships between the current document and an external resource.
     This element is most commonly used to link to CSS, but is also used to establish site icons (both "favicon" style icons and icons for the home screen and apps on mobile devices) among other things. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 
     Parameters
@@ -145,9 +145,9 @@ def link(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def meta(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <meta> tag.
+    Create a `<meta>` tag.
 
-    The <meta> HTML element represents Metadata that cannot be represented by other HTML meta-related elements, like base, link, script, style or title. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
+    The `<meta>` HTML element represents Metadata that cannot be represented by other HTML meta-related elements, like base, link, script, style or title. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 
     Parameters
     ----------
@@ -173,9 +173,9 @@ def meta(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def style(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <style> tag.
+    Create a `<style>` tag.
 
-    The <style> HTML element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the <style> element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
+    The `<style>` HTML element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the `<style>` element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
 
     Parameters
     ----------
@@ -201,9 +201,9 @@ def style(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def title(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <title> tag.
+    Create a `<title>` tag.
 
-    The <title> HTML element defines the document's title that is shown in a Browser's title bar or a page's tab. It only contains text; tags within the element are ignored. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
+    The `<title>` HTML element defines the document's title that is shown in a Browser's title bar or a page's tab. It only contains text; tags within the element are ignored. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 
     Parameters
     ----------
@@ -229,9 +229,9 @@ def title(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def body(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <body> tag.
+    Create a `<body>` tag.
 
-    The <body> HTML element represents the content of an HTML document. There can be only one <body> element in a document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
+    The `<body>` HTML element represents the content of an HTML document. There can be only one `<body>` element in a document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
 
     Parameters
     ----------
@@ -257,9 +257,9 @@ def body(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def address(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <address> tag.
+    Create a `<address>` tag.
 
-    The <address> HTML element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
+    The `<address>` HTML element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
 
     Parameters
     ----------
@@ -285,9 +285,9 @@ def address(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def article(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <article> tag.
+    Create a `<article>` tag.
 
-    The <article> HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
+    The `<article>` HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
 
     Parameters
     ----------
@@ -313,9 +313,9 @@ def article(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def aside(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <aside> tag.
+    Create a `<aside>` tag.
 
-    The <aside> HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
+    The `<aside>` HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
 
     Parameters
     ----------
@@ -341,9 +341,9 @@ def aside(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def footer(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <footer> tag.
+    Create a `<footer>` tag.
 
-    The <footer> HTML element represents a footer for its nearest sectioning content or sectioning root element. A <footer> typically contains information about the author of the section, copyright data or links to related documents. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
+    The `<footer>` HTML element represents a footer for its nearest sectioning content or sectioning root element. A `<footer>` typically contains information about the author of the section, copyright data or links to related documents. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
 
     Parameters
     ----------
@@ -369,9 +369,9 @@ def footer(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def header(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <header> tag.
+    Create a `<header>` tag.
 
-    The <header> HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
+    The `<header>` HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
 
     Parameters
     ----------
@@ -397,9 +397,9 @@ def header(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def h1(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <h1> tag.
+    Create a `<h1>` tag.
 
-    The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1
+    The `<h1>` to `<h6>` HTML elements represent six levels of section headings. `<h1>` is the highest section level and `<h6>` is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1
 
     Parameters
     ----------
@@ -425,9 +425,9 @@ def h1(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def h2(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <h2> tag.
+    Create a `<h2>` tag.
 
-    The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2
+    The `<h1>` to `<h6>` HTML elements represent six levels of section headings. `<h1>` is the highest section level and `<h6>` is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2
 
     Parameters
     ----------
@@ -453,9 +453,9 @@ def h2(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def h3(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <h3> tag.
+    Create a `<h3>` tag.
 
-    The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3
+    The `<h1>` to `<h6>` HTML elements represent six levels of section headings. `<h1>` is the highest section level and `<h6>` is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3
 
     Parameters
     ----------
@@ -481,9 +481,9 @@ def h3(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def h4(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <h4> tag.
+    Create a `<h4>` tag.
 
-    The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4
+    The `<h1>` to `<h6>` HTML elements represent six levels of section headings. `<h1>` is the highest section level and `<h6>` is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4
 
     Parameters
     ----------
@@ -509,9 +509,9 @@ def h4(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def h5(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <h5> tag.
+    Create a `<h5>` tag.
 
-    The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5
+    The `<h1>` to `<h6>` HTML elements represent six levels of section headings. `<h1>` is the highest section level and `<h6>` is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5
 
     Parameters
     ----------
@@ -537,9 +537,9 @@ def h5(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def h6(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <h6> tag.
+    Create a `<h6>` tag.
 
-    The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6
+    The `<h1>` to `<h6>` HTML elements represent six levels of section headings. `<h1>` is the highest section level and `<h6>` is the lowest. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6
 
     Parameters
     ----------
@@ -565,9 +565,9 @@ def h6(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def main(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <main> tag.
+    Create a `<main>` tag.
 
-    The <main> HTML element represents the dominant content of the body of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
+    The `<main>` HTML element represents the dominant content of the body of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
 
     Parameters
     ----------
@@ -593,9 +593,9 @@ def main(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def nav(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <nav> tag.
+    Create a `<nav>` tag.
 
-    The <nav> HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
+    The `<nav>` HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
 
     Parameters
     ----------
@@ -621,9 +621,9 @@ def nav(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagA
 
 def section(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <section> tag.
+    Create a `<section>` tag.
 
-    The <section> HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
+    The `<section>` HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
 
     Parameters
     ----------
@@ -649,9 +649,9 @@ def section(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def blockquote(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <blockquote> tag.
+    Create a `<blockquote>` tag.
 
-    The <blockquote> HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the cite element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
+    The `<blockquote>` HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the cite element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
 
     Parameters
     ----------
@@ -677,9 +677,9 @@ def blockquote(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwarg
 
 def dd(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <dd> tag.
+    Create a `<dd>` tag.
 
-    The <dd> HTML element provides the description, definition, or value for the preceding term (dt) in a description list (dl). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
+    The `<dd>` HTML element provides the description, definition, or value for the preceding term (dt) in a description list (dl). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 
     Parameters
     ----------
@@ -705,9 +705,9 @@ def dd(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def div(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <div> tag.
+    Create a `<div>` tag.
 
-    The <div> HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
+    The `<div>` HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
 
     Parameters
     ----------
@@ -733,9 +733,9 @@ def div(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagA
 
 def dl(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <dl> tag.
+    Create a `<dl>` tag.
 
-    The <dl> HTML element represents a description list. The element encloses a list of groups of terms (specified using the dt element) and descriptions (provided by dd elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
+    The `<dl>` HTML element represents a description list. The element encloses a list of groups of terms (specified using the dt element) and descriptions (provided by dd elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 
     Parameters
     ----------
@@ -761,9 +761,9 @@ def dl(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def dt(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <dt> tag.
+    Create a `<dt>` tag.
 
-    The <dt> HTML element specifies a term in a description or definition list, and as such must be used inside a dl element. It is usually followed by a dd element; however, multiple <dt> elements in a row indicate several terms that are all defined by the immediate next dd element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
+    The `<dt>` HTML element specifies a term in a description or definition list, and as such must be used inside a dl element. It is usually followed by a dd element; however, multiple `<dt>` elements in a row indicate several terms that are all defined by the immediate next dd element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 
     Parameters
     ----------
@@ -789,9 +789,9 @@ def dt(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def figcaption(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <figcaption> tag.
+    Create a `<figcaption>` tag.
 
-    The <figcaption> HTML element represents a caption or legend describing the rest of the contents of its parent figure element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
+    The `<figcaption>` HTML element represents a caption or legend describing the rest of the contents of its parent figure element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
 
     Parameters
     ----------
@@ -817,9 +817,9 @@ def figcaption(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwarg
 
 def figure(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <figure> tag.
+    Create a `<figure>` tag.
 
-    The <figure> HTML element represents self-contained content, potentially with an optional caption, which is specified using the figcaption element. The figure, its caption, and its contents are referenced as a single unit. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
+    The `<figure>` HTML element represents self-contained content, potentially with an optional caption, which is specified using the figcaption element. The figure, its caption, and its contents are referenced as a single unit. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
 
     Parameters
     ----------
@@ -845,9 +845,9 @@ def figure(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def hr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <hr> tag.
+    Create a `<hr>` tag.
 
-    The <hr> HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
+    The `<hr>` HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
 
     Parameters
     ----------
@@ -873,9 +873,9 @@ def hr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def li(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <li> tag.
+    Create a `<li>` tag.
 
-    The <li> HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (ol), an unordered list (ul), or a menu (menu). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
+    The `<li>` HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (ol), an unordered list (ul), or a menu (menu). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 
     Parameters
     ----------
@@ -901,9 +901,9 @@ def li(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def menu(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <menu> tag.
+    Create a `<menu>` tag.
 
-    The <menu> HTML element is a semantic alternative to ul. It represents an unordered list of items (represented by li elements), each of these represent a link or other command that the user can activate. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
+    The `<menu>` HTML element is a semantic alternative to ul. It represents an unordered list of items (represented by li elements), each of these represent a link or other command that the user can activate. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
 
     Parameters
     ----------
@@ -929,9 +929,9 @@ def menu(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def ol(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <ol> tag.
+    Create a `<ol>` tag.
 
-    The <ol> HTML element represents an ordered list of items — typically rendered as a numbered list. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
+    The `<ol>` HTML element represents an ordered list of items — typically rendered as a numbered list. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 
     Parameters
     ----------
@@ -957,9 +957,9 @@ def ol(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def p(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <p> tag.
+    Create a `<p>` tag.
 
-    The <p> HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
+    The `<p>` HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
 
     Parameters
     ----------
@@ -985,9 +985,9 @@ def p(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAtt
 
 def pre(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <pre> tag.
+    Create a `<pre>` tag.
 
-    The <pre> HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
+    The `<pre>` HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
 
     Parameters
     ----------
@@ -1013,9 +1013,9 @@ def pre(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def ul(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <ul> tag.
+    Create a `<ul>` tag.
 
-    The <ul> HTML element represents an unordered list of items, typically rendered as a bulleted list. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
+    The `<ul>` HTML element represents an unordered list of items, typically rendered as a bulleted list. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 
     Parameters
     ----------
@@ -1041,9 +1041,9 @@ def ul(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def a(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <a> tag.
+    Create a `<a>` tag.
 
-    The <a> HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+    The `<a>` HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 
     Parameters
     ----------
@@ -1069,9 +1069,9 @@ def a(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def abbr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <abbr> tag.
+    Create a `<abbr>` tag.
 
-    The <abbr> HTML element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
+    The `<abbr>` HTML element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 
     Parameters
     ----------
@@ -1097,9 +1097,9 @@ def abbr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def b(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <b> tag.
+    Create a `<b>` tag.
 
-    The <b> HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use <b> for styling text; instead, you should use the CSS font-weight property to create boldface text, or the strong element to indicate that text is of special importance. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
+    The `<b>` HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use `<b>` for styling text; instead, you should use the CSS font-weight property to create boldface text, or the strong element to indicate that text is of special importance. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
 
     Parameters
     ----------
@@ -1125,9 +1125,9 @@ def b(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def bdi(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <bdi> tag.
+    Create a `<bdi>` tag.
 
-    The <bdi> HTML element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
+    The `<bdi>` HTML element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
 
     Parameters
     ----------
@@ -1153,9 +1153,9 @@ def bdi(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def bdo(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <bdo> tag.
+    Create a `<bdo>` tag.
 
-    The <bdo> HTML element overrides the current directionality of text, so that the text within is rendered in a different direction. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
+    The `<bdo>` HTML element overrides the current directionality of text, so that the text within is rendered in a different direction. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
 
     Parameters
     ----------
@@ -1181,9 +1181,9 @@ def bdo(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def br(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <br> tag.
+    Create a `<br>` tag.
 
-    The <br> HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
+    The `<br>` HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 
     Parameters
     ----------
@@ -1209,9 +1209,9 @@ def br(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagA
 
 def cite(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <cite> tag.
+    Create a `<cite>` tag.
 
-    The <cite> HTML element is used to describe a reference to a cited creative work, and must include the title of that work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
+    The `<cite>` HTML element is used to describe a reference to a cited creative work, and must include the title of that work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
 
     Parameters
     ----------
@@ -1237,9 +1237,9 @@ def cite(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def code(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <code> tag.
+    Create a `<code>` tag.
 
-    The <code> HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent default monospace font. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
+    The `<code>` HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent default monospace font. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
 
     Parameters
     ----------
@@ -1265,9 +1265,9 @@ def code(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def data(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <data> tag.
+    Create a `<data>` tag.
 
-    The <data> HTML element links a given piece of content with a machine-readable translation. If the content is time- or date-related, the time element must be used. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
+    The `<data>` HTML element links a given piece of content with a machine-readable translation. If the content is time- or date-related, the time element must be used. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
 
     Parameters
     ----------
@@ -1293,9 +1293,9 @@ def data(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def dfn(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <dfn> tag.
+    Create a `<dfn>` tag.
 
-    The <dfn> HTML element is used to indicate the term being defined within the context of a definition phrase or sentence. The p element, the dt/dd pairing, or the section element which is the nearest ancestor of the <dfn> is considered to be the definition of the term. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
+    The `<dfn>` HTML element is used to indicate the term being defined within the context of a definition phrase or sentence. The p element, the dt/dd pairing, or the section element which is the nearest ancestor of the `<dfn>` is considered to be the definition of the term. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
 
     Parameters
     ----------
@@ -1321,9 +1321,9 @@ def dfn(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def em(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <em> tag.
+    Create a `<em>` tag.
 
-    The <em> HTML element marks text that has stress emphasis. The <em> element can be nested, with each level of nesting indicating a greater degree of emphasis. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
+    The `<em>` HTML element marks text that has stress emphasis. The `<em>` element can be nested, with each level of nesting indicating a greater degree of emphasis. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
 
     Parameters
     ----------
@@ -1349,9 +1349,9 @@ def em(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagA
 
 def i(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <i> tag.
+    Create a `<i>` tag.
 
-    The <i> HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the <i> naming of this element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
+    The `<i>` HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the `<i>` naming of this element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 
     Parameters
     ----------
@@ -1377,9 +1377,9 @@ def i(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def kbd(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <kbd> tag.
+    Create a `<kbd>` tag.
 
-    The <kbd> HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <kbd> element using its default monospace font, although this is not mandated by the HTML standard. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
+    The `<kbd>` HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a `<kbd>` element using its default monospace font, although this is not mandated by the HTML standard. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
 
     Parameters
     ----------
@@ -1405,9 +1405,9 @@ def kbd(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def mark(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <mark> tag.
+    Create a `<mark>` tag.
 
-    The <mark> HTML element represents text which is marked or highlighted for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
+    The `<mark>` HTML element represents text which is marked or highlighted for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
 
     Parameters
     ----------
@@ -1433,9 +1433,9 @@ def mark(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def q(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <q> tag.
+    Create a `<q>` tag.
 
-    The <q> HTML element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the blockquote element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
+    The `<q>` HTML element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the blockquote element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 
     Parameters
     ----------
@@ -1461,9 +1461,9 @@ def q(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def rp(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <rp> tag.
+    Create a `<rp>` tag.
 
-    The <rp> HTML element is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the ruby element. One <rp> element should enclose each of the opening and closing parentheses that wrap the rt element that contains the annotation's text. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
+    The `<rp>` HTML element is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the ruby element. One `<rp>` element should enclose each of the opening and closing parentheses that wrap the rt element that contains the annotation's text. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
 
     Parameters
     ----------
@@ -1489,9 +1489,9 @@ def rp(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def rt(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <rt> tag.
+    Create a `<rt>` tag.
 
-    The <rt> HTML element specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The <rt> element must always be contained within a ruby element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
+    The `<rt>` HTML element specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The `<rt>` element must always be contained within a ruby element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
 
     Parameters
     ----------
@@ -1517,9 +1517,9 @@ def rt(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def ruby(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <ruby> tag.
+    Create a `<ruby>` tag.
 
-    The <ruby> HTML element represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
+    The `<ruby>` HTML element represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
 
     Parameters
     ----------
@@ -1545,9 +1545,9 @@ def ruby(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def s(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <s> tag.
+    Create a `<s>` tag.
 
-    The <s> HTML element renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the del and ins elements, as appropriate. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
+    The `<s>` HTML element renders text with a strikethrough, or a line through it. Use the `<s>` element to represent things that are no longer relevant or no longer accurate. However, `<s>` is not appropriate when indicating document edits; for that, use the del and ins elements, as appropriate. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
 
     Parameters
     ----------
@@ -1573,9 +1573,9 @@ def s(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def samp(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <samp> tag.
+    Create a `<samp>` tag.
 
-    The <samp> HTML element is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
+    The `<samp>` HTML element is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
 
     Parameters
     ----------
@@ -1601,9 +1601,9 @@ def samp(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def small(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <small> tag.
+    Create a `<small>` tag.
 
-    The <small> HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
+    The `<small>` HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
 
     Parameters
     ----------
@@ -1629,9 +1629,9 @@ def small(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def span(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <span> tag.
+    Create a `<span>` tag.
 
-    The <span> HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. <span> is very much like a div element, but div is a block-level element whereas a <span> is an inline element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
+    The `<span>` HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. `<span>` is very much like a div element, but div is a block-level element whereas a `<span>` is an inline element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
 
     Parameters
     ----------
@@ -1657,9 +1657,9 @@ def span(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def strong(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <strong> tag.
+    Create a `<strong>` tag.
 
-    The <strong> HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
+    The `<strong>` HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
 
     Parameters
     ----------
@@ -1685,9 +1685,9 @@ def strong(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def sub(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <sub> tag.
+    Create a `<sub>` tag.
 
-    The <sub> HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub
+    The `<sub>` HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub
 
     Parameters
     ----------
@@ -1713,9 +1713,9 @@ def sub(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def sup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <sup> tag.
+    Create a `<sup>` tag.
 
-    The <sup> HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup
+    The `<sup>` HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup
 
     Parameters
     ----------
@@ -1741,9 +1741,9 @@ def sup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def time(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <time> tag.
+    Create a `<time>` tag.
 
-    The <time> HTML element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
+    The `<time>` HTML element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 
     Parameters
     ----------
@@ -1769,9 +1769,9 @@ def time(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def u(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <u> tag.
+    Create a `<u>` tag.
 
-    The <u> HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
+    The `<u>` HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
 
     Parameters
     ----------
@@ -1797,9 +1797,9 @@ def u(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAt
 
 def var(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <var> tag.
+    Create a `<var>` tag.
 
-    The <var> HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
+    The `<var>` HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
 
     Parameters
     ----------
@@ -1825,9 +1825,9 @@ def var(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def wbr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <wbr> tag.
+    Create a `<wbr>` tag.
 
-    The <wbr> HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
+    The `<wbr>` HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
 
     Parameters
     ----------
@@ -1853,9 +1853,9 @@ def wbr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def area(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <area> tag.
+    Create a `<area>` tag.
 
-    The <area> HTML element defines an area inside an image map that has predefined clickable areas. An image map allows geometric areas on an image to be associated with Hyperlink. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
+    The `<area>` HTML element defines an area inside an image map that has predefined clickable areas. An image map allows geometric areas on an image to be associated with Hyperlink. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
 
     Parameters
     ----------
@@ -1881,9 +1881,9 @@ def area(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def audio(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <audio> tag.
+    Create a `<audio>` tag.
 
-    The <audio> HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the source element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
+    The `<audio>` HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the source element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
 
     Parameters
     ----------
@@ -1909,9 +1909,9 @@ def audio(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def img(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <img> tag.
+    Create a `<img>` tag.
 
-    The <img> HTML element embeds an image into the document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+    The `<img>` HTML element embeds an image into the document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 
     Parameters
     ----------
@@ -1937,9 +1937,9 @@ def img(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def map(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <map> tag.
+    Create a `<map>` tag.
 
-    The <map> HTML element is used with area elements to define an image map (a clickable link area). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
+    The `<map>` HTML element is used with area elements to define an image map (a clickable link area). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
 
     Parameters
     ----------
@@ -1965,9 +1965,9 @@ def map(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def track(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <track> tag.
+    Create a `<track>` tag.
 
-    The <track> HTML element is used as a child of the media elements, audio and video. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
+    The `<track>` HTML element is used as a child of the media elements, audio and video. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
 
     Parameters
     ----------
@@ -1993,9 +1993,9 @@ def track(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def video(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <video> tag.
+    Create a `<video>` tag.
 
-    The <video> HTML element embeds a media player which supports video playback into the document. You can use <video> for audio content as well, but the audio element may provide a more appropriate user experience. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
+    The `<video>` HTML element embeds a media player which supports video playback into the document. You can use `<video>` for audio content as well, but the audio element may provide a more appropriate user experience. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
     Parameters
     ----------
@@ -2021,9 +2021,9 @@ def video(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def embed(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <embed> tag.
+    Create a `<embed>` tag.
 
-    The <embed> HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
+    The `<embed>` HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
 
     Parameters
     ----------
@@ -2049,9 +2049,9 @@ def embed(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def iframe(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <iframe> tag.
+    Create a `<iframe>` tag.
 
-    The <iframe> HTML element represents a nested browsing context, embedding another HTML page into the current one. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+    The `<iframe>` HTML element represents a nested browsing context, embedding another HTML page into the current one. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
     Parameters
     ----------
@@ -2077,9 +2077,9 @@ def iframe(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def object(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <object> tag.
+    Create a `<object>` tag.
 
-    The <object> HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
+    The `<object>` HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
 
     Parameters
     ----------
@@ -2105,9 +2105,9 @@ def object(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def param(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <param> tag.
+    Create a `<param>` tag.
 
-    The <param> HTML element defines parameters for an object element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param
+    The `<param>` HTML element defines parameters for an object element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param
 
     Parameters
     ----------
@@ -2133,9 +2133,9 @@ def param(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def picture(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <picture> tag.
+    Create a `<picture>` tag.
 
-    The <picture> HTML element contains zero or more source elements and one img element to offer alternative versions of an image for different display/device scenarios. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
+    The `<picture>` HTML element contains zero or more source elements and one img element to offer alternative versions of an image for different display/device scenarios. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
 
     Parameters
     ----------
@@ -2161,9 +2161,9 @@ def picture(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs:
 
 def portal(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <portal> tag.
+    Create a `<portal>` tag.
 
-    The <portal> HTML element enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/portal
+    The `<portal>` HTML element enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/portal
 
     Parameters
     ----------
@@ -2189,9 +2189,9 @@ def portal(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def source(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <source> tag.
+    Create a `<source>` tag.
 
-    The <source> HTML element specifies multiple media resources for the picture, the audio element, or the video element. It is an empty element, meaning that it has no content and does not have a closing tag. It is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
+    The `<source>` HTML element specifies multiple media resources for the picture, the audio element, or the video element. It is an empty element, meaning that it has no content and does not have a closing tag. It is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 
     Parameters
     ----------
@@ -2217,7 +2217,7 @@ def source(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def svg(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <svg> tag.
+    Create a `<svg>` tag.
 
     The svg element is a container that defines a new
     coordinate system and
@@ -2249,11 +2249,11 @@ def svg(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def math(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <math> tag.
+    Create a `<math>` tag.
 
-    The top-level element in MathML is <math>. Every valid
-    MathML instance must be wrapped in <math> tags. In
-    addition you must not nest a second <math> element in
+    The top-level element in MathML is `<math>`. Every valid
+    MathML instance must be wrapped in `<math>` tags. In
+    addition you must not nest a second `<math>` element in
     another, but you can have an arbitrary number of other child elements in
     it. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/math
 
@@ -2281,9 +2281,9 @@ def math(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def canvas(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <canvas> tag.
+    Create a `<canvas>` tag.
 
-    Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
+    Use the HTML `<canvas>` element with either the canvas scripting API or the WebGL API to draw graphics and animations. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 
     Parameters
     ----------
@@ -2309,9 +2309,9 @@ def canvas(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def noscript(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <noscript> tag.
+    Create a `<noscript>` tag.
 
-    The <noscript> HTML element defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
+    The `<noscript>` HTML element defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
 
     Parameters
     ----------
@@ -2337,9 +2337,9 @@ def noscript(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs
 
 def script(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <script> tag.
+    Create a `<script>` tag.
 
-    The <script> HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The <script> element can also be used with other languages, such as WebGL's GLSL shader programming language and JSON. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+    The `<script>` HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The `<script>` element can also be used with other languages, such as WebGL's GLSL shader programming language and JSON. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 
     Parameters
     ----------
@@ -2365,9 +2365,9 @@ def script(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def ins(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <ins> tag.
+    Create a `<ins>` tag.
 
-    The <ins> HTML element represents a range of text that has been added to a document. You can use the del element to similarly represent a range of text that has been deleted from the document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
+    The `<ins>` HTML element represents a range of text that has been added to a document. You can use the del element to similarly represent a range of text that has been deleted from the document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
 
     Parameters
     ----------
@@ -2393,9 +2393,9 @@ def ins(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Tag
 
 def caption(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <caption> tag.
+    Create a `<caption>` tag.
 
-    The <caption> HTML element specifies the caption (or title) of a table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
+    The `<caption>` HTML element specifies the caption (or title) of a table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
 
     Parameters
     ----------
@@ -2421,9 +2421,9 @@ def caption(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def col(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <col> tag.
+    Create a `<col>` tag.
 
-    The <col> HTML element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a colgroup element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
+    The `<col>` HTML element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a colgroup element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
 
     Parameters
     ----------
@@ -2449,9 +2449,9 @@ def col(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagA
 
 def colgroup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <colgroup> tag.
+    Create a `<colgroup>` tag.
 
-    The <colgroup> HTML element defines a group of columns within a table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
+    The `<colgroup>` HTML element defines a group of columns within a table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
 
     Parameters
     ----------
@@ -2477,9 +2477,9 @@ def colgroup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def table(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <table> tag.
+    Create a `<table>` tag.
 
-    The <table> HTML element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
+    The `<table>` HTML element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
 
     Parameters
     ----------
@@ -2505,9 +2505,9 @@ def table(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def tbody(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <tbody> tag.
+    Create a `<tbody>` tag.
 
-    The <tbody> HTML element encapsulates a set of table rows (tr elements), indicating that they comprise the body of the table (table). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
+    The `<tbody>` HTML element encapsulates a set of table rows (tr elements), indicating that they comprise the body of the table (table). Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
 
     Parameters
     ----------
@@ -2533,9 +2533,9 @@ def tbody(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def td(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <td> tag.
+    Create a `<td>` tag.
 
-    The <td> HTML element defines a cell of a table that contains data. It participates in the table model. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
+    The `<td>` HTML element defines a cell of a table that contains data. It participates in the table model. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
 
     Parameters
     ----------
@@ -2561,9 +2561,9 @@ def td(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def tfoot(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <tfoot> tag.
+    Create a `<tfoot>` tag.
 
-    The <tfoot> HTML element defines a set of rows summarizing the columns of the table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
+    The `<tfoot>` HTML element defines a set of rows summarizing the columns of the table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
 
     Parameters
     ----------
@@ -2589,9 +2589,9 @@ def tfoot(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def th(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <th> tag.
+    Create a `<th>` tag.
 
-    The <th> HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
+    The `<th>` HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
 
     Parameters
     ----------
@@ -2617,9 +2617,9 @@ def th(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def thead(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <thead> tag.
+    Create a `<thead>` tag.
 
-    The <thead> HTML element defines a set of rows defining the head of the columns of the table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
+    The `<thead>` HTML element defines a set of rows defining the head of the columns of the table. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
 
     Parameters
     ----------
@@ -2645,9 +2645,9 @@ def thead(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Ta
 
 def tr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <tr> tag.
+    Create a `<tr>` tag.
 
-    The <tr> HTML element defines a row of cells in a table. The row's cells can then be established using a mix of td (data cell) and th (header cell) elements. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
+    The `<tr>` HTML element defines a row of cells in a table. The row's cells can then be established using a mix of td (data cell) and th (header cell) elements. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
 
     Parameters
     ----------
@@ -2673,9 +2673,9 @@ def tr(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAt
 
 def button(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <button> tag.
+    Create a `<button>` tag.
 
-    The <button> HTML element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
+    The `<button>` HTML element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
 
     Parameters
     ----------
@@ -2701,9 +2701,9 @@ def button(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def datalist(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <datalist> tag.
+    Create a `<datalist>` tag.
 
-    The <datalist> HTML element contains a set of option elements that represent the permissible or recommended options available to choose from within other controls. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
+    The `<datalist>` HTML element contains a set of option elements that represent the permissible or recommended options available to choose from within other controls. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
 
     Parameters
     ----------
@@ -2729,9 +2729,9 @@ def datalist(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs
 
 def fieldset(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <fieldset> tag.
+    Create a `<fieldset>` tag.
 
-    The <fieldset> HTML element is used to group several controls as well as labels (label) within a web form. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
+    The `<fieldset>` HTML element is used to group several controls as well as labels (label) within a web form. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
 
     Parameters
     ----------
@@ -2757,9 +2757,9 @@ def fieldset(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def form(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <form> tag.
+    Create a `<form>` tag.
 
-    The <form> HTML element represents a document section containing interactive controls for submitting information. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+    The `<form>` HTML element represents a document section containing interactive controls for submitting information. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 
     Parameters
     ----------
@@ -2785,9 +2785,9 @@ def form(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: Tag
 
 def input(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <input> tag.
+    Create a `<input>` tag.
 
-    The <input> HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The <input> element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+    The `<input>` HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The `<input>` element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 
     Parameters
     ----------
@@ -2813,9 +2813,9 @@ def input(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def label(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <label> tag.
+    Create a `<label>` tag.
 
-    The <label> HTML element represents a caption for an item in a user interface. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
+    The `<label>` HTML element represents a caption for an item in a user interface. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
 
     Parameters
     ----------
@@ -2841,9 +2841,9 @@ def label(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def legend(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <legend> tag.
+    Create a `<legend>` tag.
 
-    The <legend> HTML element represents a caption for the content of its parent fieldset. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
+    The `<legend>` HTML element represents a caption for the content of its parent fieldset. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
 
     Parameters
     ----------
@@ -2869,9 +2869,9 @@ def legend(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def meter(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <meter> tag.
+    Create a `<meter>` tag.
 
-    The <meter> HTML element represents either a scalar value within a known range or a fractional value. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
+    The `<meter>` HTML element represents either a scalar value within a known range or a fractional value. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
 
     Parameters
     ----------
@@ -2897,9 +2897,9 @@ def meter(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: T
 
 def optgroup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <optgroup> tag.
+    Create a `<optgroup>` tag.
 
-    The <optgroup> HTML element creates a grouping of options within a select element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
+    The `<optgroup>` HTML element creates a grouping of options within a select element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
 
     Parameters
     ----------
@@ -2925,9 +2925,9 @@ def optgroup(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs:
 
 def option(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <option> tag.
+    Create a `<option>` tag.
 
-    The <option> HTML element is used to define an item contained in a select, an optgroup, or a datalist element. As such, <option> can represent menu items in popups and other lists of items in an HTML document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
+    The `<option>` HTML element is used to define an item contained in a select, an optgroup, or a datalist element. As such, `<option>` can represent menu items in popups and other lists of items in an HTML document. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
 
     Parameters
     ----------
@@ -2953,9 +2953,9 @@ def option(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def output(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <output> tag.
+    Create a `<output>` tag.
 
-    The <output> HTML element is a container element into which a site or app can inject the results of a calculation or the outcome of a user action. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
+    The `<output>` HTML element is a container element into which a site or app can inject the results of a calculation or the outcome of a user action. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
 
     Parameters
     ----------
@@ -2981,9 +2981,9 @@ def output(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def progress(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <progress> tag.
+    Create a `<progress>` tag.
 
-    The <progress> HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
+    The `<progress>` HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 
     Parameters
     ----------
@@ -3009,9 +3009,9 @@ def progress(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs
 
 def select(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <select> tag.
+    Create a `<select>` tag.
 
-    The <select> HTML element represents a control that provides a menu of options: Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
+    The `<select>` HTML element represents a control that provides a menu of options: Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 
     Parameters
     ----------
@@ -3037,9 +3037,9 @@ def select(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: 
 
 def textarea(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <textarea> tag.
+    Create a `<textarea>` tag.
 
-    The <textarea> HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
+    The `<textarea>` HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 
     Parameters
     ----------
@@ -3065,9 +3065,9 @@ def textarea(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs
 
 def details(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <details> tag.
+    Create a `<details>` tag.
 
-    The <details> HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the summary element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
+    The `<details>` HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the summary element. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 
     Parameters
     ----------
@@ -3093,9 +3093,9 @@ def details(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def dialog(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <dialog> tag.
+    Create a `<dialog>` tag.
 
-    The <dialog> HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
+    The `<dialog>` HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 
     Parameters
     ----------
@@ -3121,9 +3121,9 @@ def dialog(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: T
 
 def summary(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <summary> tag.
+    Create a `<summary>` tag.
 
-    The <summary> HTML element specifies a summary, caption, or legend for a details element's disclosure box. Clicking the <summary> element toggles the state of the parent <details> element open and closed. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
+    The `<summary>` HTML element specifies a summary, caption, or legend for a details element's disclosure box. Clicking the `<summary>` element toggles the state of the parent `<details>` element open and closed. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
 
     Parameters
     ----------
@@ -3149,9 +3149,9 @@ def summary(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = True, **kwargs: 
 
 def slot(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <slot> tag.
+    Create a `<slot>` tag.
 
-    The <slot> HTML element—part of the Web Components technology suite—is a placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
+    The `<slot>` HTML element—part of the Web Components technology suite—is a placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
 
     Parameters
     ----------
@@ -3177,9 +3177,9 @@ def slot(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: Ta
 
 def template(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = False, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <template> tag.
+    Create a `<template>` tag.
 
-    The <template> HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
+    The `<template>` HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript. Learn more at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 
     Parameters
     ----------

--- a/scripts/generate_tags.py
+++ b/scripts/generate_tags.py
@@ -75,7 +75,7 @@ _INLINE_TAG_NAMES = {
 tag_template = '''
 def {name}(*args: TagChild | TagAttrs, _add_ws: TagAttrValue = {add_ws}, **kwargs: TagAttrValue) -> Tag:
     """
-    Create a <{name}> tag.
+    Create a `<{name}>` tag.
 
     {desc}
 
@@ -116,6 +116,9 @@ def generate_tag_code(url: str) -> str:
         # spaces, or else it will confuse Sphinx when generating docs.
         if "\n" in x["desc"]:
             x["desc"] = re.sub("\n\\s+", "\n    ", x["desc"])
+            # Escape HTML tags so they don't wreck our docs
+            x["desc"] = re.sub("<", "&lt;", x["desc"])
+            x["desc"] = re.sub(">", "&gt;", x["desc"])
 
         code += "\n" + tag_template.format(
             name=x["name"],

--- a/scripts/generate_tags.py
+++ b/scripts/generate_tags.py
@@ -114,11 +114,10 @@ def generate_tag_code(url: str) -> str:
         # The descriptions sometimes have multiple lines, with inconsistent indentation
         # on lines after the first. We need to make the indentation consistently four
         # spaces, or else it will confuse Sphinx when generating docs.
-        if "\n" in x["desc"]:
-            x["desc"] = re.sub("\n\\s+", "\n    ", x["desc"])
-            # Escape HTML tags so they don't wreck our docs
-            x["desc"] = re.sub("<", "&lt;", x["desc"])
-            x["desc"] = re.sub(">", "&gt;", x["desc"])
+        x["desc"] = re.sub("\n\\s+", "\n    ", x["desc"])
+        # Escape HTML tags so they don't wreck our docs
+        x["desc"] = re.sub("<", "&lt;", x["desc"])
+        x["desc"] = re.sub(">", "&gt;", x["desc"])
 
         code += "\n" + tag_template.format(
             name=x["name"],

--- a/scripts/generate_tags.py
+++ b/scripts/generate_tags.py
@@ -111,13 +111,18 @@ def generate_tag_code(url: str) -> str:
         # TODO: still provide this, but with underscores?
         if x["name"] == "del":
             continue
+
         # The descriptions sometimes have multiple lines, with inconsistent indentation
         # on lines after the first. We need to make the indentation consistently four
         # spaces, or else it will confuse Sphinx when generating docs.
         x["desc"] = re.sub("\n\\s+", "\n    ", x["desc"])
+
         # Escape HTML tags so they don't wreck our docs
-        x["desc"] = re.sub("<", "&lt;", x["desc"])
-        x["desc"] = re.sub(">", "&gt;", x["desc"])
+        # Wrap HTML tags in code block
+        x["desc"] = re.sub(r"<([^>\n ]+)>", r"`<\1>`", x["desc"])
+        # Escape rogue < and >
+        x["desc"] = re.sub("(?<!`)<", "&lt;", x["desc"])
+        x["desc"] = re.sub(">(?!`)", "&gt;", x["desc"])
 
         code += "\n" + tag_template.format(
             name=x["name"],


### PR DESCRIPTION
We're using the name and title of the `htmltools.tags` functions in https://shiny.posit.co/py/api/core/ui.tags.html but they're unprotected HTML, resulting in a broken table.

Fixes https://github.com/posit-dev/py-shiny/issues/1337

This was reported on Discord and then by Randy. Thanks @gregswinehart for the push to find the fix.

I haven't re-generated docs. I'm hoping @schloerke might have the time to carry this fix through to https://shiny.posit.co/py