### PR TITLE
feat(TagList)!: `TagList` now inherits from `collections.UserList`, instead of `typing.List`

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.9"]
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
     defaults:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
     defaults:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.9"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
     defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `Tag` and `TagList`'s method `.get_html_string()` now both return `str` instead of `HTML`. (#86)
 
-* Strings added to `HTML` objects, now return `HTML` objects. E.g. `HTML_value + str_value` and `str_value_ + HTML_value` both return `HTML` objects. To maintain a `str` result, call `str()` on your `HTML` objects before adding them to strings. (#86)
+* Strings added to `HTML` objects, now return `HTML` objects. E.g. `HTML_value + str_value` and `str_value + HTML_value` both return `HTML` objects. To maintain a `str` result, call `str()` on your `HTML` objects before adding them to other strings values. (#86)
+
+* Items added to `TagList` objects, now return `TagList` objects. E.g. `TagList_value + arr_value` and `arr_value + TagList_value` both return new `TagList` objects. To maintain a `list` result, call `list()` on your `TagList` objects before combining them to other list objects. (#97)
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `HTML` no longer inherits from `str`. It now inherits from `collections.UserString`. This was done to avoid confusion between `str` and `HTML` objects. (#86)
 
+* `TagList` no longer inherits from `list`. It now inherits from `collections.UserList`. This was done to avoid confusion between `list` and `TagList` objects. (#97)
+
 * `Tag` and `TagList`'s method `.get_html_string()` now both return `str` instead of `HTML`. (#86)
 
 * Strings added to `HTML` objects, now return `HTML` objects. E.g. `HTML_value + str_value` and `str_value_ + HTML_value` both return `HTML` objects. To maintain a `str` result, call `str()` on your `HTML` objects before adding them to strings. (#86)

--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.3.9001"
+__version__ = "0.5.3.9002"
 
 from . import svg, tags
 from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport] # noqa: F401

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -254,7 +254,10 @@ class ReprHtml(Protocol):
 # =============================================================================
 # TagList class
 # =============================================================================
-class TagList(UserList[TagNode]):
+_TagListParentClass = UserList if sys.version_info <= (3, 8) else UserList[TagNode]
+
+
+class TagList(_TagListParentClass):
     """
     Create an HTML tag list (i.e., a fragment of HTML)
 

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -293,7 +293,7 @@ class TagList(UserList[TagNode]):
         Insert tag children before a given index.
         """
 
-        self.data[i:i] = _tagchilds_to_tagnodes([item])
+        self[i:i] = _tagchilds_to_tagnodes([item])
 
     def tagify(self) -> "TagList":
         """
@@ -305,16 +305,16 @@ class TagList(UserList[TagNode]):
         # Iterate backwards because if we hit a Tagifiable object, it may be replaced
         # with 0, 1, or more items (if it returns TagList).
         for i in reversed(range(len(cp))):
-            child = cp.data[i]
+            child = cp[i]
 
             if isinstance(child, Tagifiable):
                 tagified_child = child.tagify()
                 if isinstance(tagified_child, TagList):
                     # If the Tagifiable object returned a TagList, flatten it into this
                     # one.
-                    cp.data[i : i + 1] = _tagchilds_to_tagnodes(tagified_child)
+                    cp[i : i + 1] = _tagchilds_to_tagnodes(tagified_child)
                 else:
-                    cp.data[i] = tagified_child
+                    cp[i] = tagified_child
 
             elif isinstance(child, MetadataNode):
                 cp[i] = copy(child)
@@ -341,7 +341,7 @@ class TagList(UserList[TagNode]):
             The path to the generated HTML file.
         """
 
-        return HTMLDocument(self.data).save_html(
+        return HTMLDocument(self).save_html(
             file, libdir=libdir, include_version=include_version
         )
 
@@ -381,7 +381,7 @@ class TagList(UserList[TagNode]):
         first_child = True
         prev_was_add_ws = add_ws
 
-        for child in self.data:
+        for child in self:
             if isinstance(child, MetadataNode):
                 continue
 
@@ -446,7 +446,7 @@ class TagList(UserList[TagNode]):
         """
 
         deps: list[HTMLDependency] = []
-        for x in self.data:
+        for x in self:
             if isinstance(x, HTMLDependency):
                 deps.append(x)
             elif isinstance(x, Tag):

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -254,7 +254,11 @@ class ReprHtml(Protocol):
 # =============================================================================
 # TagList class
 # =============================================================================
-_TagListParentClass = UserList if sys.version_info <= (3, 8) else UserList[TagNode]
+if sys.version_info > (3, 8):
+    _TagListParentClass = UserList[TagNode]
+else:
+    # In Python 3.8 and earlier, `UserList` does not like to be subclassed
+    _TagListParentClass = UserList
 
 
 class TagList(_TagListParentClass):

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -254,14 +254,7 @@ class ReprHtml(Protocol):
 # =============================================================================
 # TagList class
 # =============================================================================
-if sys.version_info > (3, 8):
-    _TagListParentClass = UserList[TagNode]
-else:
-    # In Python 3.8 and earlier, `UserList` does not like to be subclassed
-    _TagListParentClass = UserList
-
-
-class TagList(_TagListParentClass):
+class TagList(UserList[TagNode]):
     """
     Create an HTML tag list (i.e., a fragment of HTML)
 

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -271,6 +271,12 @@ class TagList(UserList[TagNode]):
     <div id="foo" class="bar"></div>
     """
 
+    def _should_not_expand(self, x: object) -> TypeIs[str]:
+        """
+        Check if an object should not be expanded into a list of children.
+        """
+        return isinstance(x, str)
+
     def __init__(self, *args: TagChild) -> None:
         super().__init__(_tagchilds_to_tagnodes(args))
 
@@ -278,11 +284,6 @@ class TagList(UserList[TagNode]):
         """
         Extend the children by appending an iterable of children.
         """
-
-        # If other is a string (an iterable), convert it to a list of s.
-        if isinstance(other, str):
-            other = [other]
-
         super().extend(_tagchilds_to_tagnodes(other))
 
     def append(self, item: TagChild, *args: TagChild) -> None:
@@ -304,8 +305,7 @@ class TagList(UserList[TagNode]):
         Return a new TagList with the item added at the end.
         """
 
-        should_not_expand = isinstance(item, str)
-        if should_not_expand:
+        if self._should_not_expand(item):
             return TagList(self, item)
 
         return TagList(self, *item)
@@ -315,8 +315,7 @@ class TagList(UserList[TagNode]):
         Return a new TagList with the item added to the beginning.
         """
 
-        should_not_expand = isinstance(item, str)
-        if should_not_expand:
+        if self._should_not_expand(item):
             return TagList(item, self)
 
         return TagList(*item, self)
@@ -1926,6 +1925,9 @@ def consolidate_attrs(
 # Convert a list of TagChild objects to a list of TagNode objects. Does not alter input
 # object.
 def _tagchilds_to_tagnodes(x: Iterable[TagChild]) -> list[TagNode]:
+    if isinstance(x, str):
+        return [x]
+
     result = flatten(x)
     for i, item in enumerate(result):
         if isinstance(item, (int, float)):

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -279,6 +279,10 @@ class TagList(UserList[TagNode]):
         Extend the children by appending an iterable of children.
         """
 
+        # If other is a string (an iterable), convert it to a list of s.
+        if isinstance(other, str):
+            other = [other]
+
         super().extend(_tagchilds_to_tagnodes(other))
 
     def append(self, item: TagChild, *args: TagChild) -> None:

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -299,6 +299,28 @@ class TagList(UserList[TagNode]):
 
         self[i:i] = _tagchilds_to_tagnodes([item])
 
+    def __add__(self, item: Iterable[TagChild]) -> TagList:
+        """
+        Return a new TagList with the item added at the end.
+        """
+
+        should_not_expand = isinstance(item, str)
+        if should_not_expand:
+            return TagList(self, item)
+
+        return TagList(self, *item)
+
+    def __radd__(self, item: Iterable[TagChild]) -> TagList:
+        """
+        Return a new TagList with the item added to the beginning.
+        """
+
+        should_not_expand = isinstance(item, str)
+        if should_not_expand:
+            return TagList(item, self)
+
+        return TagList(*item, self)
+
     def tagify(self) -> "TagList":
         """
         Convert any tagifiable children to Tag/TagList objects.

--- a/htmltools/_util.py
+++ b/htmltools/_util.py
@@ -89,12 +89,13 @@ def _flatten_recurse(x: Iterable[T | None], result: list[T]) -> None:
     from ._core import TagList
 
     for item in x:
-        if isinstance(item, TagList):
-            _flatten_recurse(item.data, result)  # pyright: ignore[reportArgumentType]
-        elif isinstance(item, (list, tuple)):
+        if isinstance(item, (list, tuple, TagList)):
             # Don't yet know how to specify recursive generic types, so we'll tell
             # the type checker to ignore this line.
-            _flatten_recurse(item, result)  # pyright: ignore[reportUnknownArgumentType]
+            _flatten_recurse(
+                item,  # pyright: ignore[reportUnknownArgumentType]
+                result,  # pyright: ignore[reportArgumentType]
+            )
         elif item is not None:
             result.append(item)
 

--- a/htmltools/_util.py
+++ b/htmltools/_util.py
@@ -86,8 +86,12 @@ def flatten(x: Iterable[Union[T, None]]) -> list[T]:
 # Having this separate function and passing along `result` is faster than defining
 # a closure inside of `flatten()` (and not passing `result`).
 def _flatten_recurse(x: Iterable[T | None], result: list[T]) -> None:
+    from ._core import TagList
+
     for item in x:
-        if isinstance(item, (list, tuple)):
+        if isinstance(item, TagList):
+            _flatten_recurse(item, result)
+        elif isinstance(item, (list, tuple)):
             # Don't yet know how to specify recursive generic types, so we'll tell
             # the type checker to ignore this line.
             _flatten_recurse(item, result)  # pyright: ignore[reportUnknownArgumentType]

--- a/htmltools/_util.py
+++ b/htmltools/_util.py
@@ -90,7 +90,7 @@ def _flatten_recurse(x: Iterable[T | None], result: list[T]) -> None:
 
     for item in x:
         if isinstance(item, TagList):
-            _flatten_recurse(item, result)
+            _flatten_recurse(item.data, result)  # pyright: ignore[reportArgumentType]
         elif isinstance(item, (list, tuple)):
             # Don't yet know how to specify recursive generic types, so we'll tell
             # the type checker to ignore this line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,56 +1,47 @@
 [build-system]
-requires = [
-  "setuptools",
-  "wheel"
-]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "htmltools"
 dynamic = ["version"]
-authors = [{name = "Carson Sievert", email = "carson@rstudio.com"}]
+authors = [{ name = "Carson Sievert", email = "carson@rstudio.com" }]
 description = "Tools for HTML generation and output."
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 keywords = ["html"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Text Processing :: Markup :: HTML"
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Text Processing :: Markup :: HTML",
 ]
-dependencies = [
-  "typing-extensions>=3.10.0.0",
-  "packaging>=20.9",
-]
-requires-python = ">=3.8"
+dependencies = ["typing-extensions>=3.10.0.0", "packaging>=20.9"]
+requires-python = ">=3.9"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/rstudio/py-htmltools/issues"
 Source = "https://github.com/rstudio/py-htmltools"
 
 [project.optional-dependencies]
-test = [
-    "pytest>=6.2.4",
-    "syrupy>=4.6.0"
-]
+test = ["pytest>=6.2.4", "syrupy>=4.6.0"]
 dev = [
-    "black>=24.2.0",
-    "flake8>=6.0.0",
-    "Flake8-pyproject",
-    "isort>=5.11.2",
-    "pyright>=1.1.348",
-    "pre-commit>=2.15.0",
-    "wheel",
-    "build"
+  "black>=24.2.0",
+  "flake8>=6.0.0",
+  "Flake8-pyproject",
+  "isort>=5.11.2",
+  "pyright>=1.1.348",
+  "pre-commit>=2.15.0",
+  "wheel",
+  "build",
 ]
 
 [tool.setuptools]
@@ -59,7 +50,7 @@ include-package-data = true
 zip-safe = false
 
 [tool.setuptools.dynamic]
-version = {attr = "htmltools.__version__"}
+version = { attr = "htmltools.__version__" }
 
 [tool.setuptools.package-data]
 htmltools = ["py.typed"]

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -763,6 +763,56 @@ def test_taglist_add():
     assert_tag_list("foo" + tl_bar, ["foo", "bar"])
 
 
+def test_taglist_methods():
+    # Testing methods from https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
+    #
+    # Operation | Result | Notes
+    # --------- | ------ | -----
+    # x in s    | True if an item of s is equal to x, else False | (1)
+    # x not in s | False if an item of s is equal to x, else True | (1)
+    # s + t     | the concatenation of s and t | (6)(7)
+    # s * n or n * s | equivalent to adding s to itself n times | (2)(7)
+    # s[i]      | ith item of s, origin 0 | (3)
+    # s[i:j]    | slice of s from i to j | (3)(4)
+    # s[i:j:k]  | slice of s from i to j with step k | (3)(5)
+    # len(s)    | length of s
+    # min(s)    | smallest item of s
+    # max(s)    | largest item of s
+    # s.index(x[, i[, j]]) | index of the first occurrence of x in s (at or after index i and before index j) | (8)
+    # s.count(x) | total number of occurrences of x in s
+
+    x = TagList("foo", "bar", "foo", "baz")
+    y = TagList("a", "b", "c")
+
+    assert "bar" in x
+    assert "qux" not in x
+
+    add = x + y
+    assert isinstance(add, TagList)
+    assert list(add) == ["foo", "bar", "foo", "baz", "a", "b", "c"]
+
+    mul = x * 2
+    assert isinstance(mul, TagList)
+    assert list(mul) == ["foo", "bar", "foo", "baz", "foo", "bar", "foo", "baz"]
+
+    assert x[1] == "bar"
+    assert x[1:3] == TagList("bar", "foo")
+    assert mul[1:6:2] == TagList("bar", "baz", "bar")
+
+    assert len(x) == 4
+
+    assert min(x) == "bar"  # pyright: ignore[reportArgumentType]
+    assert max(x) == "foo"  # pyright: ignore[reportArgumentType]
+
+    assert x.index("foo") == 0
+    assert x.index("foo", 1) == 2
+    with pytest.raises(ValueError):
+        x.index("foo", 1, 1)
+
+    assert x.count("foo") == 2
+    assert mul.count("foo") == 4
+
+
 def test_taglist_extend():
     x = TagList("foo")
     y = ["bar", "baz"]


### PR DESCRIPTION
This will allow for `orjson` to utilize custom printing methods for TagList, rather than waiting until an inner item is printed.

Follows similar logic and benefits of #86 

---------------------

**Note!** Drop support for python 3.8 as python 3.8's `collection.UserList` can not be subscripted to `UserList[TagNode]`

```
    _TagListParentClass = UserList[TagNode]
E   TypeError: 'ABCMeta' object is not subscriptable
```

Since we're going to drop 3.8 when 3.13 comes out in early Oct'24, I am not pursuing a fix for 3.8