### PR TITLE
Bump dev version; drop Python 3.9, add 3.13/3.14

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", "3.9"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
     defaults:

--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0"
+__version__ = "0.6.0.9000"
 
 from . import svg, tags
 from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport] # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,17 +15,18 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Text Processing :: Markup :: HTML",
 ]
 dependencies = ["typing-extensions>=3.10.0.0", "packaging>=20.9"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/rstudio/py-htmltools/issues"
@@ -60,7 +61,7 @@ ignore = "E203, E302, E402, E501, E704, F403, F405, W503"
 extend-exclude = "docs, .venv, venv, typings, e2e, build"
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- Bump version to 0.6.0.9000 for development
- Drop Python 3.9 support (requires-python >= 3.10)
- Add Python 3.13 and 3.14 to CI matrix and classifiers
- Pin black target-version to py310