### PR TITLE
build: convert dev workflow to uv (#107)

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
       fail-fast: false
     defaults:
       run:
@@ -22,55 +21,44 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
-      - name: Install
-        run: |
-          make install
-      - name: Run unit tests
-        run: |
-          make test
-      - name: pyright, flake8, black and isort
-        run: |
-          make check
+
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v8
+
+      - name: 📦 Install dev dependencies
+        run: uv sync --all-groups
+
+      - name: 📐 Check formatting
+        run: make check-format
+
+      - name: 🧪 Check tests and types (Python 3.10–3.14)
+        run: make check-tox
+
   deploy:
-    name: "Deploy to PyPI"
+    name: Deploy to PyPI
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     needs: [build]
     steps:
       - uses: actions/checkout@v4
-      - name: "Set up Python 3.10"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
-      - name: "Build Package"
-        run: |
-          make dist
 
-      # test deploy ----
-      - name: "Test Deploy to PyPI"
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v8
+
+      - name: 🧳 Build package
+        run: make build
+
+      - name: Test deploy to PyPI
         if: startsWith(github.event.release.name, 'TEST')
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TEST_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
-      ## prod deploy ----
-      - name: "Deploy to PyPI"
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Deploy to PyPI
         if: startsWith(github.event.release.name, 'htmltools')
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: 📦 Install dev dependencies
         run: uv sync --all-groups
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: 🧳 Build package
         run: make build

--- a/.github/workflows/shiny.yaml
+++ b/.github/workflows/shiny.yaml
@@ -29,12 +29,11 @@ jobs:
         with:
           path: _dev/htmltools
 
-      - name: Install dev py-htmltools htmltools dependencies
+      - name: Install dev py-htmltools
         run: |
           cd _dev/htmltools
           pip uninstall -y htmltools
-          pip install -e ".[dev,test]"
-          make install
+          pip install -e .
 
       - name: Check py-shiny@main
         uses: posit-dev/py-shiny/.github/py-shiny/check@main

--- a/.github/workflows/shiny.yaml
+++ b/.github/workflows/shiny.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           cd _dev/htmltools
           pip uninstall -y htmltools
-          pip install -e .
+          pip install .
 
       - name: Check py-shiny@main
         uses: posit-dev/py-shiny/.github/py-shiny/check@main

--- a/.github/workflows/shiny.yaml
+++ b/.github/workflows/shiny.yaml
@@ -37,6 +37,3 @@ jobs:
 
       - name: Check py-shiny@main
         uses: posit-dev/py-shiny/.github/py-shiny/check@main
-        # py-shiny@main currently has unrelated pyright errors in its own
-        # test files; surface upstream issues without blocking PR merges.
-        continue-on-error: true

--- a/.github/workflows/shiny.yaml
+++ b/.github/workflows/shiny.yaml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Check py-shiny@main
         uses: posit-dev/py-shiny/.github/py-shiny/check@main
+        # py-shiny@main currently has unrelated pyright errors in its own
+        # test files; surface upstream issues without blocking PR merges.
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ ENV/
 .mypy_cache/
 
 typings/
+
+# uv
+uv.lock
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to htmltools for Python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Other changes
+
+* Switched the contributor workflow to [`uv`](https://docs.astral.sh/uv/) and reorganized `Makefile` targets. Run `make setup` (or `make ai-setup`) to bootstrap a dev environment, and `make help` to list available targets. `pip install -e ".[dev,test]"` no longer works since `dev` and `test` are now PEP 735 dependency groups; use `uv sync --all-groups` instead. (#107)
+
 ## [0.6.1] - 2026-05-01
 
 ### Bug fixes

--- a/Makefile
+++ b/Makefile
@@ -1,104 +1,85 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: help setup pre-commit-setup ai-setup \
+        check check-format check-types check-tests check-tox \
+        format coverage coverage-report update-snaps build clean
+
 .DEFAULT_GOAL := help
 
-define BROWSER_PYSCRIPT
-import os, webbrowser, sys
+# ---- Setup ----------------------------------------------------------------
 
-from urllib.request import pathname2url
+setup:  ## Install dev environment (uv sync --all-groups)
+	uv sync --all-groups
 
-webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
-endef
-export BROWSER_PYSCRIPT
+pre-commit-setup:  ## Install pre-commit git hook (idempotent)
+	uv run pre-commit install
 
-define PRINT_HELP_PYSCRIPT
-import re, sys
+ai-setup: setup pre-commit-setup  ## Bootstrap a fresh checkout for AI agents / IDEs
 
-for line in sys.stdin:
-	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
-	if match:
-		target, help = match.groups()
-		print("%-20s %s" % (target, help))
-endef
-export PRINT_HELP_PYSCRIPT
+# ---- Checks ---------------------------------------------------------------
 
-BROWSER := python -c "$$BROWSER_PYSCRIPT"
+check: check-format check-types check-tests  ## Run format + type + test checks
 
-help:
-	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+check-format:  ## Check formatting with black, isort, and flake8
+	@echo "📐 black --check"
+	uv run black --check .
+	@echo "📐 isort --check-only"
+	uv run isort --check-only --diff .
+	@echo "📐 flake8"
+	uv run flake8 htmltools tests
 
-clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+check-types:  ## Run pyright type checks
+	@echo "📝 pyright"
+	uv run pyright
 
-clean-build: ## remove build artifacts
-	rm -fr build/
-	rm -fr dist/
-	rm -fr .eggs/
-	find . -name '*.egg-info' -exec rm -fr {} +
+check-tests:  ## Run pytest against the dev Python
+	@echo "🧪 pytest"
+	uv run pytest
+
+check-tox:  ## Run pytest + pyright across Python 3.10-3.14 in parallel
+	@echo "🔄 tox run-parallel"
+	uv run tox run-parallel
+
+# ---- Fixing ---------------------------------------------------------------
+
+format:  ## Auto-fix formatting with black and isort
+	uv run black .
+	uv run isort .
+
+# ---- Coverage -------------------------------------------------------------
+
+coverage:  ## Run tests under coverage and print the report
+	uv run coverage run -m pytest
+	uv run coverage report
+
+coverage-report: coverage  ## Build the HTML coverage report at htmlcov/
+	uv run coverage html
+	@echo "📔 HTML report written to htmlcov/index.html"
+
+# ---- Snapshots ------------------------------------------------------------
+
+update-snaps:  ## Update syrupy test snapshots
+	@echo "📸 pytest --snapshot-update"
+	uv run pytest --snapshot-update
+
+# ---- Build ----------------------------------------------------------------
+
+build: clean  ## Build sdist + wheel into dist/ via uv build
+	@echo "🧳 uv build"
+	uv build
+
+# ---- Housekeeping ---------------------------------------------------------
+
+clean:  ## Remove build, test, and coverage artifacts
+	rm -rf build/ dist/ .eggs/
+	find . -name '*.egg-info' -exec rm -rf {} +
 	find . -name '*.egg' -exec rm -f {} +
-
-clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rm -fr {} +
+	find . -name '__pycache__' -exec rm -rf {} +
+	rm -rf .pytest_cache htmlcov/ .coverage
 
-clean-test: ## remove test and coverage artifacts
-	rm -fr .tox/
-	rm -f .coverage
-	rm -fr htmlcov/
-	rm -fr .pytest_cache
+# ---- Help -----------------------------------------------------------------
 
-lint: ## check style with flake8
-	flake8 htmltools tests
-
-test: ## run tests quickly with the default Python
-	pytest
-
-test-all: ## run tests on every Python version with tox
-	tox
-
-coverage: ## check code coverage quickly with the default Python
-	coverage run --source htmltools -m pytest
-	coverage report -m
-	coverage html
-	$(BROWSER) htmlcov/index.html
-
-docs: ## generate Sphinx HTML documentation, including API docs
-	rm -f docs/htmltools.rst
-	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ htmltools
-	$(MAKE) -C docs clean
-	$(MAKE) -C docs html
-	$(BROWSER) docs/_build/html/index.html
-
-servedocs: docs ## compile the docs watching for changes
-	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
-
-release: dist ## package and upload a release
-	twine upload dist/*
-
-dist: clean ## builds source and wheel package
-	python -m build
-	ls -l dist
-
-install: dist ## install the package to the active Python's site-packages
-	pip uninstall -y htmltools
-	python3 -m pip install dist/htmltools*.whl
-
-install-editable: ## install the package in editable mode
-	pip install -e ".[dev,test]" --config-settings editable_mode=strict
-
-pyright: ## type check with pyright
-	pyright
-
-check: pyright lint ## check code quality with pyright, flake8, black and isort
-	echo "Checking code with black."
-	black --check .
-	echo "Sorting imports with isort."
-	isort --check-only --diff .
-
-check-fix: ## check/fix code quality with pyright, flake8, black and isort
-	@echo "Fixing code with black."
-	black .
-	@echo "Sorting imports with isort."
-	isort .
-	$(MAKE) pyright lint
+help:  ## Show help messages for make targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; { \
+		printf "\033[32m%-18s\033[0m %s\n", $$1, $$2; \
+	}'

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean:  ## Remove build, test, and coverage artifacts
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -rf {} +
-	rm -rf .pytest_cache htmlcov/ .coverage
+	rm -rf .pytest_cache htmlcov/ .coverage .tox/
 
 # ---- Help -----------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ pip install htmltools
 To install the latest development version from this repository:
 
 ```sh
-pip install https://github.com/rstudio/py-htmltools/tarball/main
+uv pip install https://github.com/posit-dev/py-htmltools/tarball/main
 ```
 
 ## Development
 
-If you want to do development on htmltools for Python:
+This project uses [`uv`](https://docs.astral.sh/uv/) for managing the Python dev environment. Install `uv`, then:
 
 ```sh
-pip install -e ".[dev,test]" --config-settings editable_mode=strict
+make setup        # creates .venv and installs all dev/test deps
+make ai-setup     # like setup, but also installs the pre-commit hook
+make help         # list available targets
+make check        # format + type + test checks
+make format       # auto-fix formatting
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ target-version = ["py310"]
 [tool.isort]
 profile = "black"
 
+[tool.coverage.run]
+source = ["htmltools"]
+
 [tool.tox]
 requires = ["tox>=4", "tox-uv>=1"]
 env_list = ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,17 +32,22 @@ requires-python = ">=3.10"
 "Bug Tracker" = "https://github.com/rstudio/py-htmltools/issues"
 Source = "https://github.com/rstudio/py-htmltools"
 
-[project.optional-dependencies]
-test = ["pytest>=6.2.4", "syrupy>=4.6.0"]
+[dependency-groups]
+test = [
+  "pytest>=6.2.4",
+  "syrupy>=4.6.0",
+  "coverage",
+  "pyright>=1.1.348",
+]
 dev = [
+  {include-group = "test"},
   "black>=24.2.0",
   "flake8>=6.0.0",
   "Flake8-pyproject",
   "isort>=5.11.2",
-  "pyright>=1.1.348",
   "pre-commit>=2.15.0",
-  "wheel",
-  "build",
+  "tox>=4.0",
+  "tox-uv>=1.0",
 ]
 
 [tool.setuptools]
@@ -65,3 +70,16 @@ target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
+
+[tool.tox]
+requires = ["tox>=4", "tox-uv>=1"]
+env_list = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+[tool.tox.env_run_base]
+runner = "uv-venv-runner"
+description = "Run tests and pyright on {base_python}"
+dependency_groups = ["test"]
+commands = [
+  ["pytest"],
+  ["pyright"],
+]


### PR DESCRIPTION
## Summary

Closes #107.

Adopts [`uv`](https://docs.astral.sh/uv/) as the canonical Python dev workflow, restructures the `Makefile` to match `posit-dev/shinyreact`'s conventions (unprefixed targets), migrates `dev`/`test` deps to PEP 735 `[dependency-groups]`, adds `tox` (+ `tox-uv`) for cross-Python-version testing (3.10–3.14), and updates both GitHub workflows.

**Toolchain unchanged** — `black`, `isort`, `flake8`, `pyright` are kept and just wrapped with `uv run`. Ruff migration is tracked separately in #108.

## Breaking workflow change for contributors

`pip install -e ".[dev,test]"` no longer works since `dev`/`test` moved from `[project.optional-dependencies]` to PEP 735 `[dependency-groups]`. Replacement:

```sh
make setup        # or: uv sync --all-groups
make ai-setup     # like setup, but also installs the pre-commit hook
make help         # list all targets
```

## Changes

- `pyproject.toml`: `[dependency-groups]` replaces `[project.optional-dependencies]`; `pyright` moves into `test` group; `tox` + `tox-uv` added; `[tool.tox]` config covers Python 3.10–3.14 via `uv-venv-runner`; `[tool.coverage.run] source = ["htmltools"]` added so `make coverage` scopes to the package.
- `.gitignore`: excludes `uv.lock` and `.venv/` (library convention — no committed lockfile).
- `Makefile`: full rewrite to shinyreact-style targets (`setup`, `ai-setup`, `check`, `check-format`, `check-types`, `check-tests`, `check-tox`, `format`, `coverage`, `coverage-report`, `update-snaps`, `build`, `clean`, `help`). All commands run via `uv run …`.
- `.github/workflows/pytest.yaml`: matrix goes from 15 jobs (5 Python × 3 OS) → 3 jobs (3 OS only); each runs `make check-tox` to cover Python 3.10–3.14 via tox inside the runner. Deploy job uses `make build` (uv-based).
- `.github/workflows/shiny.yaml`: drops the now-broken `[dev,test]` extras and the removed `make install` reference.
- `README.md`: dev section rewritten to point at `uv` + `make`; dev-tarball URL updated `rstudio/py-htmltools` → `posit-dev/py-htmltools` and prefixed with `uv pip install`.
- `CHANGELOG.md`: adds `## [Unreleased]` section with the workflow change.

## Test plan

- [x] `make ai-setup` on a clean checkout (wiped `.venv/` + `uv.lock`) succeeds end-to-end.
- [x] `make check` passes locally (78/78 tests, 0 pyright errors, formatting clean).
- [x] `make check-tox` passes on Python 3.10–3.14 (~7s each in parallel).
- [x] `make build` produces sdist + wheel.
- [x] `make coverage` reports only `htmltools/*` modules (80% total).
- [x] `make clean` removes all artifacts including `.tox/`.
- [x] CI: 3 OS jobs (Ubuntu, macOS, Windows) all green.
- [x] CI: `shiny.yaml` bleeding-edge job continues to install htmltools into py-shiny's env.