### PR TITLE
build: migrate from black/isort/flake8 to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: "24.2.0"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
     hooks:
-      - id: black
-        language_version: python3
-        exclude: ^tests/snapshots/
+      - id: ruff-check
+        args: [--config, pyproject.toml]
+      - id: ruff-format
+        args: [--config, pyproject.toml]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,18 @@
 {
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
-    "python.formatting.provider": "black",
-    "python.linting.flake8Enabled": true,
     "editor.tabSize": 2,
     "files.encoding": "utf8",
     "files.eol": "\n",
     "[python]": {
         "editor.formatOnSave": true,
         "editor.tabSize": 4,
+        "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.codeActionsOnSave": {
-            "source.organizeImports": "explicit"
+            "source.organizeImports.ruff": "explicit",
+            "source.fixAll.ruff": "explicit"
         },
     },
-    "isort.args":["--profile", "black"],
     "editor.rulers": [
         88
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Switched the contributor workflow to [`uv`](https://docs.astral.sh/uv/) and reorganized `Makefile` targets. Run `make setup` (or `make ai-setup`) to bootstrap a dev environment, and `make help` to list available targets. `pip install -e ".[dev,test]"` no longer works since `dev` and `test` are now PEP 735 dependency groups; use `uv sync --all-groups` instead. (#107)
 
+* Replaced `black`, `isort`, and `flake8` with [`ruff`](https://docs.astral.sh/ruff/) for linting and formatting. Run `make format` to auto-fix, or `make check-format` to verify. (#110)
+
 ## [0.6.1] - 2026-05-01
 
 ### Bug fixes

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,11 @@ ai-setup: setup pre-commit-setup  ## Bootstrap a fresh checkout for AI agents / 
 
 check: check-format check-types check-tests  ## Run format + type + test checks
 
-check-format:  ## Check formatting with black, isort, and flake8
-	@echo "📐 black --check"
-	uv run black --check .
-	@echo "📐 isort --check-only"
-	uv run isort --check-only --diff .
-	@echo "📐 flake8"
-	uv run flake8 htmltools tests
+check-format:  ## Check lint and formatting with ruff
+	@echo "📐 ruff check"
+	uv run ruff check .
+	@echo "📐 ruff format --check"
+	uv run ruff format --check .
 
 check-types:  ## Run pyright type checks
 	@echo "📝 pyright"
@@ -40,9 +38,9 @@ check-tox:  ## Run pytest + pyright across Python 3.10-3.14 in parallel
 
 # ---- Fixing ---------------------------------------------------------------
 
-format:  ## Auto-fix formatting with black and isort
-	uv run black .
-	uv run isort .
+format:  ## Auto-fix lint and format with ruff
+	uv run ruff check --fix .
+	uv run ruff format .
 
 # ---- Coverage -------------------------------------------------------------
 

--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -1,8 +1,6 @@
 __version__ = "0.6.1"
 
 from . import svg, tags
-from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport] # noqa: F401
-from ._core import TagChildArg  # pyright: ignore[reportUnusedImport] # noqa: F401
 from ._core import (
     HTML,
     HTMLDependency,
@@ -12,9 +10,11 @@ from ._core import (
     RenderedHTML,
     ReprHtml,
     Tag,
+    TagAttrArg,  # pyright: ignore[reportUnusedImport] # noqa: F401
     TagAttrs,
     TagAttrValue,
     TagChild,
+    TagChildArg,  # pyright: ignore[reportUnusedImport] # noqa: F401
     TagFunction,
     Tagifiable,
     TagList,

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -413,7 +413,7 @@ class TagList(UserList[TagNode]):
             # True if the previous and current node are inline; False otherwise. This
             # affects whether or not we add whitespace and indentation.
             prev_or_current_add_ws = prev_was_add_ws or (
-                (isinstance(child, Tag) and child.add_ws)
+                isinstance(child, Tag) and child.add_ws
             )
 
             if first_child:

--- a/htmltools/_util.py
+++ b/htmltools/_util.py
@@ -185,7 +185,9 @@ def http_server(port: int, path: str):
             super().__init__(*args, directory=path, **kwargs)
 
         def log_message(
-            self, format, *args  # pyright: ignore[reportMissingParameterType]
+            self,
+            format,
+            *args,  # pyright: ignore[reportMissingParameterType]
         ):
             pass
 

--- a/htmltools/_util.py
+++ b/htmltools/_util.py
@@ -186,7 +186,7 @@ def http_server(port: int, path: str):
 
         def log_message(
             self,
-            format,
+            format,  # pyright: ignore[reportMissingParameterType]
             *args,  # pyright: ignore[reportMissingParameterType]
         ):
             pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,7 @@ test = [
 ]
 dev = [
   {include-group = "test"},
-  "black>=24.2.0",
-  "flake8>=6.0.0",
-  "Flake8-pyproject",
-  "isort>=5.11.2",
+  "ruff>=0.15.0",
   "pre-commit>=2.15.0",
   "tox>=4.0",
   "tox-uv>=1.0",
@@ -61,15 +58,16 @@ version = { attr = "htmltools.__version__" }
 [tool.setuptools.package-data]
 htmltools = ["py.typed"]
 
-[tool.flake8]
-ignore = "E203, E302, E402, E501, E704, F403, F405, W503"
-extend-exclude = "docs, .venv, venv, typings, e2e, build"
+[tool.ruff]
+line-length = 88
+extend-exclude = ["docs", "typings", "build"]
 
-[tool.black]
-target-version = ["py310"]
-
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+# E501 (line too long) was ignored under the previous flake8 config; keep
+# parity. Ruff's formatter wraps where it can but does not break long string
+# literals, comments, or URLs.
+ignore = ["E501"]
 
 [tool.coverage.run]
 source = ["htmltools"]

--- a/tests/test_html_document.py
+++ b/tests/test_html_document.py
@@ -356,9 +356,9 @@ def test_save_html_utf8_encoding(monkeypatch):
 
         # Verify save_html() opened the file with encoding="utf-8"
         write_calls = [c for c in open_calls if call(f, "w", encoding="utf-8") == c]
-        assert (
-            len(write_calls) == 1
-        ), f"Expected open({f!r}, 'w', encoding='utf-8'), got: {open_calls}"
+        assert len(write_calls) == 1, (
+            f"Expected open({f!r}, 'w', encoding='utf-8'), got: {open_calls}"
+        )
 
         # Also verify the content roundtrips correctly
         with original_open(f, "r", encoding="utf-8") as fh:

--- a/tests/test_is.py
+++ b/tests/test_is.py
@@ -20,7 +20,6 @@ tag_attr_obj: TagAttrs = {"test_key": "test_value"}
 
 
 class ReprClass:
-
     def _repr_html_(self) -> str:
         return "repr_html"
 

--- a/tests/test_jsx_tags.py
+++ b/tests/test_jsx_tags.py
@@ -11,7 +11,8 @@ def test_jsx_tags():
     react_ver = [str(d.version) for d in deps if d.name == "react"][0]
     react_dom_ver = [str(d.version) for d in deps if d.name == "react-dom"][0]
 
-    assert HTMLDocument(Foo()).render()["html"] == textwrap.dedent("""\
+    assert HTMLDocument(Foo()).render()["html"] == textwrap.dedent(
+        """\
         <!DOCTYPE html>
         <html>
           <head>
@@ -34,10 +35,13 @@ def test_jsx_tags():
         })();
         </script>
           </body>
-        </html>""" % (react_ver, react_dom_ver, react_ver, react_dom_ver))
+        </html>"""
+        % (react_ver, react_dom_ver, react_ver, react_dom_ver)
+    )
 
     # Only the "top-level" tag gets wrapped in <script> tags
-    assert HTMLDocument(Foo(Bar())).render()["html"] == textwrap.dedent("""\
+    assert HTMLDocument(Foo(Bar())).render()["html"] == textwrap.dedent(
+        """\
         <!DOCTYPE html>
         <html>
           <head>
@@ -63,7 +67,9 @@ def test_jsx_tags():
         })();
         </script>
           </body>
-        </html>""" % (react_ver, react_dom_ver, react_ver, react_dom_ver))
+        </html>"""
+        % (react_ver, react_dom_ver, react_ver, react_dom_ver)
+    )
 
     x = Foo(
         span(),

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -858,8 +858,11 @@ def test_attr_vals():
     }
     test = TagList(div(**attrs), div(class_="foo").add_class("bar"))
 
-    assert str(test) == """<div true="" str="a" int="1" float="1.2"></div>
+    assert (
+        str(test)
+        == """<div true="" str="a" int="1" float="1.2"></div>
 <div class="foo bar"></div>"""
+    )
 
 
 def test_tag_normalize_attr():


### PR DESCRIPTION
## Summary
- Replaces `black` + `isort` + `flake8` with `ruff` (config in `pyproject.toml` using `select = ["E", "F", "I"]`, `ignore = ["E501"]` for parity with the prior flake8 ignore, `line-length = 88`).
- Updates `Makefile` (`check-format` / `format` targets), `.pre-commit-config.yaml` (`astral-sh/ruff-pre-commit` with ruff-check + ruff-format), and `.vscode/{settings,extensions}.json` to use ruff. New `.vscode/extensions.json` recommends `charliermarsh.ruff`.
- Separate reformat commit (`style: reformat with ruff`) for pure tool output across `htmltools/` and `tests/`.

Modeled on `posit-dev/shinyreact`. Closes #108.

## Test plan
- [x] `make check-format` passes
- [x] `make check-types` passes
- [x] `make check-tests` passes
- [x] `make check-tox` passes (Python 3.10-3.14)
- [x] `make format` is a no-op on a clean tree
- [x] After squash-merge, follow-up commit on `main` adds `.git-blame-ignore-revs` with the squash SHA so `git blame` skips the reformat noise. : https://github.com/posit-dev/py-htmltools/pull/111