### PR TITLE
build: add .git-blame-ignore-revs for ruff reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat with ruff (issue #108 migration)
+a8f3d11809075ce9fed3343c3f2eb82f5ec256e4


### PR DESCRIPTION
Adds the squash-merge SHA from #110 (the ruff migration) to `.git-blame-ignore-revs` so `git blame` skips the reformat commit.

GitHub's blame view picks the file up automatically. Contributors can opt in locally with:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Closes the post-merge follow-up from #108.