### PR TITLE
feat: TagList.tagify() raises TypeError on un-tagified content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug fixes
+
+* `TagList.tagify()` now raises `TypeError` at the boundary when a child's `.tagify()` returns a `TagList` containing an un-tagified `Tagifiable` object. The error names the offending class and slot index so buggy `.tagify()` implementations surface at the source rather than later at render time. The render-time `RuntimeError` raised by `get_html_string()` for an un-tagified child has also been clarified to include the offending class name and a hint that the tree was likely mutated after `.tagify()` was called. (#7)
+
 ### Other changes
 
 * Switched the contributor workflow to [`uv`](https://docs.astral.sh/uv/) and reorganized `Makefile` targets. Run `make setup` (or `make ai-setup`) to bootstrap a dev environment, and `make help` to list available targets. `pip install -e ".[dev,test]"` no longer works since `dev` and `test` are now PEP 735 dependency groups; use `uv sync --all-groups` instead. (#107)

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -323,6 +323,14 @@ class TagList(UserList[TagNode]):
     def tagify(self) -> "TagList":
         """
         Convert any tagifiable children to Tag/TagList objects.
+
+        Raises
+        ------
+        TypeError
+            If a child's ``.tagify()`` returned a ``TagList`` containing an
+            un-tagified ``Tagifiable`` object — i.e. the recursion was not
+            done all the way down. The error names the offending class and
+            slot index so the broken ``.tagify()`` is easy to find.
         """
 
         cp = copy(self)
@@ -343,6 +351,21 @@ class TagList(UserList[TagNode]):
 
             elif isinstance(child, MetadataNode):
                 cp[i] = copy(child)
+
+        # Post-condition: after the recursion, no bare Tagifiable may remain.
+        # Tag and TagList are themselves Tagifiable but are already-tagified
+        # shapes, so they are excluded from the check.
+        for i, child in enumerate(cp):
+            if isinstance(child, Tagifiable) and not isinstance(child, (Tag, TagList)):
+                raise TypeError(
+                    "Expected a fully tagified value, but a child .tagify() "
+                    "returned a TagList containing an un-tagified "
+                    f"{type(child).__name__} at index {i}. "
+                    "A .tagify() implementation must recursively tagify its "
+                    "return value (consider returning `something.tagify()` "
+                    "instead of `something`)."
+                )
+
         return cp
 
     def save_html(
@@ -443,7 +466,10 @@ class TagList(UserList[TagNode]):
 
             elif isinstance(child, Tagifiable):
                 raise RuntimeError(
-                    "Encountered a non-tagified object. x.tagify() must be called before x.render()"
+                    f"Encountered an un-tagified {type(child).__name__} at render time. "
+                    "This usually means the tag tree was mutated to add a "
+                    "Tagifiable object after .tagify() was called. Call "
+                    ".tagify() again before rendering."
                 )
 
             else:

--- a/tests/test_tagify.py
+++ b/tests/test_tagify.py
@@ -1,0 +1,48 @@
+import pytest
+
+from htmltools import TagList, div, span
+
+
+class _ReturnsTagifiable:
+    """A buggy Tagifiable: returns a TagList containing an un-tagified Tagifiable."""
+
+    def tagify(self) -> "TagList":
+        return TagList(_NestedTagifiable())
+
+
+class _NestedTagifiable:
+    """A Tagifiable whose .tagify() returns a plain string."""
+
+    def tagify(self) -> str:
+        return "bar"
+
+
+def test_taglist_tagify_raises_on_untagified_grandchild() -> None:
+    # The buggy wrapper returns a TagList with a still-Tagifiable child;
+    # TagList.tagify() must raise at the boundary, naming the offending type.
+    tl = TagList(_ReturnsTagifiable())
+    with pytest.raises(TypeError, match="_NestedTagifiable"):
+        tl.tagify()
+
+
+def test_tag_tagify_raises_on_untagified_grandchild() -> None:
+    # Same scenario, but via Tag.tagify(), which delegates to children.tagify().
+    with pytest.raises(TypeError, match="_NestedTagifiable"):
+        div(_ReturnsTagifiable()).tagify()
+
+
+def test_tagify_is_idempotent() -> None:
+    # .tagify() applied twice must produce the same HTML as once.
+    original = div("hello", span("world"))
+    once = original.tagify()
+    twice = once.tagify()
+    assert once.get_html_string() == twice.get_html_string()
+
+
+def test_render_guard_catches_mutation_after_tagify() -> None:
+    # The static guarantee is a snapshot at .tagify() time; if a Tagifiable
+    # is appended afterwards, the render-time guard must catch it.
+    tagified = div("hello").tagify()
+    tagified.children.append(_NestedTagifiable())
+    with pytest.raises(RuntimeError, match="_NestedTagifiable"):
+        tagified.get_html_string()


### PR DESCRIPTION
## Summary

Adds runtime guards (only) from #106, with **zero changes to type signatures**:

- `TagList.tagify()` now checks the post-recursion list for any remaining bare `Tagifiable` (excluding `Tag` / `TagList`, which are themselves `Tagifiable` but already-tagified shapes) and raises `TypeError` naming the offending class and slot index. This surfaces a broken `.tagify()` implementation at its source rather than later at render time.
- `TagList.get_html_string()`'s render-time `RuntimeError` (kept as the fallback when the tree is mutated after `.tagify()`) now also names the offending class and hints at the likely cause.
- New `tests/test_tagify.py` covering both guards plus idempotence of `.tagify()`.

Explicitly **excluded** from #106:

- All `Tagified` / `TagifiedNode` / `TagifiedTag` / `TagifiedTagList` type aliases.
- `Tag` / `TagList` becoming `Generic[ChildT]`.
- All `cast(...)` calls and `# pyright: ignore[...]` comments.
- `Tagifiable.tagify()` / `Tag.tagify()` return-type changes.
- `typing_extensions>=4.7.0` floor bump.
- `_jsx.py` / `_util.py` type-assertion-driven changes.
- `tests/test_types.py` static-type assertions.

## Test plan

- [x] `uv run pytest` — 82 passed
- [x] `uv run pyright htmltools tests` — 0 errors, 0 warnings
- [x] `uv run ruff check` / `ruff format --check` — clean