### PR TITLE
release: htmltools 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to htmltools for Python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - Unreleased
+## [0.7.0] - 2026-05-21
 
 ### Breaking changes
 


### PR DESCRIPTION
## Summary

Release prep for htmltools 0.7.0. Sets the CHANGELOG date for the 0.7.0 entry to 2026-05-21. Version in `htmltools/__init__.py` is already `0.7.0`.

## Downstream TODOs

`.github/workflows/downstream.yaml` currently pins each downstream to a feature branch (`schloerke/htmltools-105-tagified-types`) that absorbs the 0.7.0 type-system changes. Once those downstream PRs land, flip each `ref` back to `main` (or delete it to use the repo's default branch):

- [ ] [posit-dev/py-shiny#2244](https://github.com/posit-dev/py-shiny/pull/2244) — merge, then unpin `ref` for `posit-dev/py-shiny` in `downstream.yaml`
- [ ] [posit-dev/shinychat#226](https://github.com/posit-dev/shinychat/pull/226) — merge, then unpin `ref` for `posit-dev/shinychat` in `downstream.yaml`
- [ ] [posit-dev/chatlas#311](https://github.com/posit-dev/chatlas/pull/311) — merge, then unpin `ref` for `posit-dev/chatlas` in `downstream.yaml`
- [ ] [posit-dev/brand-yml#115](https://github.com/posit-dev/brand-yml/pull/115) — merge, then unpin `ref` for `posit-dev/brand-yml` in `downstream.yaml`

## Release steps (after merge)

- [ ] Tag `v0.7.0` on `main`
- [ ] Create GitHub Release named `htmltools v0.7.0` — `.github/workflows/pytest.yaml` auto-publishes to PyPI on `release: published` when the release name starts with `htmltools` (use `TEST ...` for a test.pypi dry run first if desired)

## Test plan

- [ ] CI green on this branch (pytest + downstream)
- [ ] `uv build` produces a valid wheel/sdist locally