### PR TITLE
ci(downstream): flip merged downstreams back to main

### DIFF
--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -34,7 +34,7 @@ jobs:
           - repo: posit-dev/shinychat
             ref: schloerke/htmltools-105-tagified-types  # PR #226
           - repo: posit-dev/chatlas
-            ref: schloerke/htmltools-105-tagified-types  # PR #311
+            ref: main
           - repo: posit-dev/brand-yml
             ref: main
     defaults:

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -5,8 +5,8 @@ name: Downstream
 # downstream is an independent matrix entry — failures are localized.
 #
 # Each entry's `ref` may pin to a PR branch that absorbs upstream type-
-# system changes. When the corresponding downstream PR merges, flip the
-# `ref` back to `main` (or delete it to use the default).
+# system changes. When the corresponding downstream PR merges, drop the
+# `ref` line — the step defaults to `main` when `ref` is not set.
 #
 # Candidates to consider adding later (Posit-owned consumers that import
 # htmltools symbols but don't currently have custom .tagify()):
@@ -23,30 +23,27 @@ on:
 
 jobs:
   downstream:
-    name: ${{ matrix.repo }}@${{ matrix.ref }}
+    name: ${{ matrix.repo }}@${{ matrix.ref || 'main' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - repo: posit-dev/py-shiny
-            ref: main
           - repo: posit-dev/shinychat
             ref: schloerke/htmltools-105-tagified-types  # PR #226
           - repo: posit-dev/chatlas
-            ref: main
           - repo: posit-dev/brand-yml
-            ref: main
     defaults:
       run:
         shell: bash
 
     steps:
-      - name: Checkout ${{ matrix.repo }}@${{ matrix.ref }}
+      - name: Checkout ${{ matrix.repo }}@${{ matrix.ref || 'main' }}
         uses: actions/checkout@v6
         with:
           repository: ${{ matrix.repo }}
-          ref: ${{ matrix.ref }}
+          ref: ${{ matrix.ref || 'main' }}
           fetch-depth: 0 # required by some downstreams' versioning
 
       - name: Checkout dev branch of py-htmltools

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -36,7 +36,7 @@ jobs:
           - repo: posit-dev/chatlas
             ref: schloerke/htmltools-105-tagified-types  # PR #311
           - repo: posit-dev/brand-yml
-            ref: schloerke/htmltools-105-tagified-types  # PR #115
+            ref: main
     defaults:
       run:
         shell: bash

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -31,7 +31,6 @@ jobs:
         include:
           - repo: posit-dev/py-shiny
           - repo: posit-dev/shinychat
-            ref: schloerke/htmltools-105-tagified-types  # PR #226
           - repo: posit-dev/chatlas
           - repo: posit-dev/brand-yml
     defaults:

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - repo: posit-dev/py-shiny
-            ref: schloerke/htmltools-105-tagified-types  # PR #2244
+            ref: main
           - repo: posit-dev/shinychat
             ref: schloerke/htmltools-105-tagified-types  # PR #226
           - repo: posit-dev/chatlas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to htmltools for Python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Breaking changes
+
+### New features
+
+### Bug fixes
+
+### Dependencies
+
+### Other changes
+
 ## [0.7.0] - 2026-05-21
 
 ### Breaking changes


### PR DESCRIPTION
## Summary

Flips the `ref:` for each entry in `.github/workflows/downstream.yaml` back to `main` (or removes it) as the corresponding downstream PR merges. The original workflow comment already documents this pattern.

- [x] **brand-yml** — `posit-dev/brand-yml#115` merged ([`5b911ac`](https://github.com/posit-dev/brand-yml/commit/5b911ac4b0cf6e61f77e4230db7309c73c5a07a2))
- [ ] py-shiny — `posit-dev/py-shiny#2244` open
- [ ] shinychat — `posit-dev/shinychat#226` open
- [ ] chatlas — `posit-dev/chatlas#311` open

I'll push follow-up commits to this branch as each remaining downstream PR merges, then merge this once they're all back on `main`.

## Test plan

- [ ] `Downstream` workflow on this PR shows `posit-dev/brand-yml@main` passing pyright against this branch's htmltools.